### PR TITLE
feat(editor): timeline track grouping + per-row icons

### DIFF
--- a/editor/components/control-panel/components/IconPicker.tsx
+++ b/editor/components/control-panel/components/IconPicker.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+import {
+  TRACK_ICON_KEYS,
+  TRACK_ICON_REGISTRY,
+  type TrackIconKey,
+} from './track-icons';
+
+type IconPickerProps = {
+  value: string | undefined;
+  onChange: (key: TrackIconKey) => void;
+  /** Optional icon shown when `value` is unset. */
+  fallbackKey?: TrackIconKey;
+  className?: string;
+  ariaLabel?: string;
+  /** When true, renders as a small button with no extra padding. */
+  compact?: boolean;
+};
+
+export function IconPicker({
+  value,
+  onChange,
+  fallbackKey = 'layers',
+  className,
+  ariaLabel = 'Change icon',
+  compact = true,
+}: IconPickerProps) {
+  const [open, setOpen] = useState(false);
+  const activeKey: TrackIconKey =
+    value && (TRACK_ICON_KEYS as string[]).includes(value)
+      ? (value as TrackIconKey)
+      : fallbackKey;
+  const ActiveIcon = TRACK_ICON_REGISTRY[activeKey];
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <button
+          type='button'
+          aria-label={ariaLabel}
+          onClick={(e) => e.stopPropagation()}
+          className={cn(
+            'shrink-0 inline-flex items-center justify-center rounded text-muted-foreground hover:text-foreground hover:bg-muted/60 transition-colors cursor-pointer',
+            compact ? 'h-5 w-5' : 'h-6 w-6 p-0.5',
+            className,
+          )}>
+          <ActiveIcon className='w-3.5 h-3.5' />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        align='start'
+        className='p-2 w-[228px]'
+        onClick={(e) => e.stopPropagation()}>
+        <div className='grid grid-cols-6 gap-1'>
+          {TRACK_ICON_KEYS.map((key) => {
+            const Icon = TRACK_ICON_REGISTRY[key];
+            const selected = key === activeKey;
+            return (
+              <button
+                key={key}
+                type='button'
+                aria-label={key}
+                title={key}
+                onClick={() => {
+                  onChange(key);
+                  setOpen(false);
+                }}
+                className={cn(
+                  'h-7 w-7 inline-flex items-center justify-center rounded transition-colors cursor-pointer',
+                  selected
+                    ? 'bg-blue-500/20 text-blue-300 ring-1 ring-blue-500/50'
+                    : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
+                )}>
+                <Icon className='w-4 h-4' />
+              </button>
+            );
+          })}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/editor/components/control-panel/components/TimelineGroupHeader.tsx
+++ b/editor/components/control-panel/components/TimelineGroupHeader.tsx
@@ -1,0 +1,152 @@
+'use client';
+
+import { useState, type PointerEvent as ReactPointerEvent } from 'react';
+import {
+  ChevronDown,
+  ChevronRight,
+  GripVertical,
+  Trash2,
+  Pencil,
+} from 'lucide-react';
+import { Input as ShadcnInput } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import type { TrackGroup } from '../hooks/use-timeline-state';
+import { IconPicker } from './IconPicker';
+import { getGroupIcon } from './track-icons';
+import type { TrackIconKey } from './track-icons';
+
+type TimelineGroupHeaderProps = {
+  group: TrackGroup;
+  width: number;
+  height: number;
+  childCount: number;
+  onToggleCollapsed: () => void;
+  onRename: (label: string) => void;
+  onSetIcon: (icon: TrackIconKey) => void;
+  onDelete: () => void;
+  onPointerDownGrip?: (e: ReactPointerEvent<SVGElement>) => void;
+  isBeingDragged?: boolean;
+  showDropIndicator?: boolean;
+};
+
+export function TimelineGroupHeader({
+  group,
+  width,
+  height,
+  childCount,
+  onToggleCollapsed,
+  onRename,
+  onSetIcon,
+  onDelete,
+  onPointerDownGrip,
+  isBeingDragged,
+  showDropIndicator,
+}: TimelineGroupHeaderProps) {
+  const [editing, setEditing] = useState(false);
+  const [labelDraft, setLabelDraft] = useState(group.label);
+  const Icon = getGroupIcon(group.icon, group.collapsed);
+
+  const commitRename = () => {
+    const trimmed = labelDraft.trim();
+    if (trimmed && trimmed !== group.label) onRename(trimmed);
+    setEditing(false);
+  };
+
+  return (
+    <div
+      className={`flex flex-col border-b border-border/50 group/group relative ${
+        isBeingDragged ? 'bg-blue-500/10' : ''
+      }`}>
+      {showDropIndicator && (
+        <div className='absolute left-0 right-0 top-0 h-0.5 bg-blue-500 z-20 pointer-events-none' />
+      )}
+      <div className='flex' style={{ height }}>
+        <div
+          className='shrink-0 bg-muted/60 flex items-center gap-1.5 px-2 sticky left-0 z-10 border-r border-border/30'
+          style={{ width }}>
+          <GripVertical
+            className='w-3 h-3 shrink-0 text-muted-foreground/50 opacity-0 group-hover/group:opacity-100 transition-opacity cursor-grab active:cursor-grabbing'
+            onPointerDown={onPointerDownGrip}
+          />
+          <button
+            type='button'
+            aria-label={group.collapsed ? 'Expand group' : 'Collapse group'}
+            onClick={onToggleCollapsed}
+            className='shrink-0 inline-flex items-center justify-center h-5 w-5 rounded text-muted-foreground hover:text-foreground hover:bg-muted/60 cursor-pointer'>
+            {group.collapsed ? (
+              <ChevronRight className='w-3.5 h-3.5' />
+            ) : (
+              <ChevronDown className='w-3.5 h-3.5' />
+            )}
+          </button>
+          <IconPicker
+            value={group.icon}
+            fallbackKey={group.collapsed ? 'folder' : 'folder-open'}
+            onChange={onSetIcon}
+            ariaLabel='Change group icon'
+          />
+          {editing ? (
+            <ShadcnInput
+              autoFocus
+              className='text-sm bg-card border border-border rounded px-1 py-0.5 flex-1 min-w-0 outline-none focus:border-blue-500'
+              value={labelDraft}
+              onChange={(e) => setLabelDraft(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') commitRename();
+                else if (e.key === 'Escape') {
+                  setLabelDraft(group.label);
+                  setEditing(false);
+                }
+              }}
+              onBlur={commitRename}
+              onClick={(e) => e.stopPropagation()}
+            />
+          ) : (
+            <span
+              className='text-sm font-medium text-foreground/90 truncate flex-1'
+              onDoubleClick={(e) => {
+                e.stopPropagation();
+                setLabelDraft(group.label);
+                setEditing(true);
+              }}>
+              {group.label}
+              <span className='ml-1.5 text-xs text-muted-foreground'>
+                ({childCount})
+              </span>
+            </span>
+          )}
+          {!editing && (
+            <div className='flex items-center gap-0.5 opacity-0 group-hover/group:opacity-100 transition-opacity'>
+              <Button
+                variant='ghost'
+                size='icon'
+                aria-label='Rename group'
+                className='h-5 w-5 cursor-pointer'
+                onClick={(e) => {
+                  e.stopPropagation();
+                  setLabelDraft(group.label);
+                  setEditing(true);
+                }}>
+                <Pencil className='w-3 h-3' />
+              </Button>
+              <Button
+                variant='ghost'
+                size='icon'
+                aria-label='Ungroup tracks'
+                title='Ungroup (keep tracks)'
+                className='h-5 w-5 cursor-pointer text-muted-foreground hover:text-red-400'
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDelete();
+                }}>
+                <Trash2 className='w-3 h-3' />
+              </Button>
+            </div>
+          )}
+        </div>
+        {/* Right side spans across timeline; visually empty header band. */}
+        <div className='flex-1 bg-muted/20' />
+      </div>
+    </div>
+  );
+}

--- a/editor/components/control-panel/components/TimelineGroupHeader.tsx
+++ b/editor/components/control-panel/components/TimelineGroupHeader.tsx
@@ -62,7 +62,7 @@ export function TimelineGroupHeader({
       )}
       <div className='flex' style={{ height }}>
         <div
-          className='shrink-0 bg-muted/60 flex items-center gap-1.5 px-2 sticky left-0 z-10 border-r border-border/30'
+          className='shrink-0 bg-muted/60 flex items-center gap-1 px-1 sticky left-0 z-10 border-r border-border/30'
           style={{ width }}>
           <GripVertical
             className='w-3 h-3 shrink-0 text-muted-foreground/50 opacity-0 group-hover/group:opacity-100 transition-opacity cursor-grab active:cursor-grabbing'

--- a/editor/components/control-panel/components/TimelinePanel.tsx
+++ b/editor/components/control-panel/components/TimelinePanel.tsx
@@ -27,8 +27,17 @@ import {
   type Clip,
   type Keyframe,
   type Track,
+  type TrackGroup,
+  type TimelineRowRef,
   type TimelineState,
 } from '../hooks/use-timeline-state';
+import { TimelineGroupHeader } from './TimelineGroupHeader';
+import { IconPicker } from './IconPicker';
+import {
+  getTrackIcon,
+  type TrackIconKey,
+} from './track-icons';
+import { FolderPlus } from 'lucide-react';
 import { useServerTimelinePlayback } from '../hooks/use-server-timeline-playback';
 import {
   Play,
@@ -297,6 +306,14 @@ export const TimelinePanel = memo(function TimelinePanel({
     addTrack,
     deleteTrack,
     reorderTrack,
+    moveTrackTo,
+    setTrackIcon,
+    addGroup,
+    deleteGroup,
+    renameGroup,
+    setGroupCollapsed,
+    setGroupIcon,
+    moveGroup,
     replaceInputId,
     swapClipInput,
     updateClipSettings,
@@ -1084,6 +1101,11 @@ export const TimelinePanel = memo(function TimelinePanel({
     originY: number;
     currentIndex: number;
   } | null>(null);
+  const groupDragRef = useRef<{
+    groupId: string;
+    originY: number;
+    currentIndex: number;
+  } | null>(null);
   const [trackDropIndex, setTrackDropIndex] = useState<number | null>(null);
 
   // ── Sync ruler scroll with tracks scroll ──────────────
@@ -1787,23 +1809,90 @@ export const TimelinePanel = memo(function TimelinePanel({
 
   const snapThresholdMs = useMemo(() => pxToMs(SNAP_THRESHOLD_PX), [pxToMs]);
 
-  // ── Determine which track the pointer is over ────
-  const getTrackIndexAtY = useCallback(
+  // ── Visible rows: rootOrder expanded with group children (collapse-aware) ─
+  type VisibleRow =
+    | {
+        kind: 'track';
+        track: Track;
+        groupId?: string;
+        /** Drop target for inserting BEFORE this row. */
+        dropTarget:
+          | { kind: 'root'; index: number }
+          | { kind: 'group'; groupId: string; index: number };
+        indent: boolean;
+      }
+    | {
+        kind: 'group';
+        group: TrackGroup;
+        rootIndex: number;
+        dropTarget: { kind: 'root'; index: number };
+      };
+
+  const visibleRows = useMemo<VisibleRow[]>(() => {
+    const trackById = new Map(state.tracks.map((t) => [t.id, t]));
+    const groupById = new Map(state.groups.map((g) => [g.id, g]));
+    const out: VisibleRow[] = [];
+    state.rootOrder.forEach((ref, rootIndex) => {
+      if (ref.kind === 'track') {
+        const t = trackById.get(ref.id);
+        if (!t) return;
+        out.push({
+          kind: 'track',
+          track: t,
+          dropTarget: { kind: 'root', index: rootIndex },
+          indent: false,
+        });
+      } else {
+        const g = groupById.get(ref.id);
+        if (!g) return;
+        out.push({
+          kind: 'group',
+          group: g,
+          rootIndex,
+          dropTarget: { kind: 'root', index: rootIndex },
+        });
+        if (!g.collapsed) {
+          g.trackIds.forEach((tid, childIdx) => {
+            const t = trackById.get(tid);
+            if (!t) return;
+            out.push({
+              kind: 'track',
+              track: t,
+              groupId: g.id,
+              dropTarget: { kind: 'group', groupId: g.id, index: childIdx },
+              indent: true,
+            });
+          });
+        }
+      }
+    });
+    return out;
+  }, [state.rootOrder, state.tracks, state.groups]);
+
+  // ── Determine which row the pointer is over ────
+  const getRowIndexAtY = useCallback(
     (relativeY: number): number => {
       let accumulated = 0;
-      for (let i = 0; i < state.tracks.length; i++) {
-        const h =
-          TRACK_HEIGHT +
-          (automationVisibleTracks.has(state.tracks[i].id)
-            ? AUTOMATION_LANE_HEIGHT
-            : 0);
+      for (let i = 0; i < visibleRows.length; i++) {
+        const row = visibleRows[i];
+        const isTrack = row.kind === 'track';
+        const h = isTrack
+          ? TRACK_HEIGHT +
+            (automationVisibleTracks.has(row.track.id)
+              ? AUTOMATION_LANE_HEIGHT
+              : 0)
+          : TRACK_HEIGHT;
         if (relativeY < accumulated + h) return i;
         accumulated += h;
       }
-      return state.tracks.length - 1;
+      return Math.max(0, visibleRows.length - 1);
     },
-    [state.tracks, automationVisibleTracks],
+    [visibleRows, automationVisibleTracks],
   );
+
+  /** Legacy alias used by clip drag helpers. Returns visible-row index, but
+   *  callers that needed a track-only index get translated via getTrackIdAtY. */
+  const getTrackIndexAtY = getRowIndexAtY;
 
   const getTrackIdAtY = useCallback(
     (clientY: number): string | null => {
@@ -1812,13 +1901,12 @@ export const TimelinePanel = memo(function TimelinePanel({
       const containerRect = container.getBoundingClientRect();
       const scrollTop = container.scrollTop;
       const relativeY = clientY - containerRect.top + scrollTop;
-      const trackIndex = getTrackIndexAtY(relativeY);
-      if (trackIndex >= 0 && trackIndex < state.tracks.length) {
-        return state.tracks[trackIndex].id;
-      }
+      const idx = getRowIndexAtY(relativeY);
+      const row = visibleRows[idx];
+      if (row && row.kind === 'track') return row.track.id;
       return null;
     },
-    [state.tracks, getTrackIndexAtY],
+    [visibleRows, getRowIndexAtY],
   );
 
   const handleClipPointerDown = useCallback(
@@ -1996,19 +2084,65 @@ export const TimelinePanel = memo(function TimelinePanel({
         const containerRect = container.getBoundingClientRect();
         const scrollTop = container.scrollTop;
         const relativeY = e.clientY - containerRect.top + scrollTop;
-        let targetIndex = getTrackIndexAtY(relativeY);
+        let targetIndex = getRowIndexAtY(relativeY);
         targetIndex = Math.max(
           0,
-          Math.min(targetIndex, state.tracks.length - 1),
+          Math.min(targetIndex, Math.max(0, visibleRows.length - 1)),
         );
-        const targetTrack = state.tracks[targetIndex];
-        if (targetTrack && targetTrack.id === OUTPUT_TRACK_ID) {
+        const targetRow = visibleRows[targetIndex];
+        if (
+          targetRow &&
+          targetRow.kind === 'track' &&
+          targetRow.track.id === OUTPUT_TRACK_ID
+        ) {
           return;
         }
         setTrackDropIndex(targetIndex);
-        if (targetIndex !== trackDrag.currentIndex) {
-          reorderTrack(trackDrag.trackId, targetIndex);
+        if (targetIndex !== trackDrag.currentIndex && targetRow) {
+          moveTrackTo(trackDrag.trackId, targetRow.dropTarget);
           trackDrag.currentIndex = targetIndex;
+        }
+        return;
+      }
+
+      // ── Group reorder drag ──
+      const groupDrag = groupDragRef.current;
+      if (groupDrag) {
+        const container = scrollContainerRef.current;
+        if (!container) return;
+        const containerRect = container.getBoundingClientRect();
+        const scrollTop = container.scrollTop;
+        const relativeY = e.clientY - containerRect.top + scrollTop;
+        let targetIndex = getRowIndexAtY(relativeY);
+        targetIndex = Math.max(
+          0,
+          Math.min(targetIndex, Math.max(0, visibleRows.length - 1)),
+        );
+        const targetRow = visibleRows[targetIndex];
+        if (!targetRow) return;
+        // Groups can only be dropped at root positions. Use the row's root
+        // index (groups themselves carry rootIndex; child track rows carry
+        // their parent group's rootIndex via dropTarget=group).
+        let rootIndex: number;
+        if (targetRow.kind === 'group') {
+          rootIndex = targetRow.rootIndex;
+        } else {
+          const dt = targetRow.dropTarget;
+          if (dt.kind === 'root') {
+            rootIndex = dt.index;
+          } else {
+            // hovering inside a group's children — clamp to that group's root pos
+            const ownerGroupId = dt.groupId;
+            const ownerIdx = state.rootOrder.findIndex(
+              (r) => r.kind === 'group' && r.id === ownerGroupId,
+            );
+            rootIndex = ownerIdx >= 0 ? ownerIdx : state.rootOrder.length - 1;
+          }
+        }
+        setTrackDropIndex(targetIndex);
+        if (targetIndex !== groupDrag.currentIndex) {
+          moveGroup(groupDrag.groupId, rootIndex);
+          groupDrag.currentIndex = targetIndex;
         }
         return;
       }
@@ -2219,11 +2353,18 @@ export const TimelinePanel = memo(function TimelinePanel({
 
     const handlePointerUp = () => {
       const hadActiveDrag =
-        keyframeDragRef.current || dragRef.current || trackDragRef.current;
+        keyframeDragRef.current ||
+        dragRef.current ||
+        trackDragRef.current ||
+        groupDragRef.current;
       keyframeDragRef.current = null;
       dragRef.current = null;
       if (trackDragRef.current) {
         trackDragRef.current = null;
+        setTrackDropIndex(null);
+      }
+      if (groupDragRef.current) {
+        groupDragRef.current = null;
         setTrackDropIndex(null);
       }
       if (hadActiveDrag) {
@@ -2241,6 +2382,7 @@ export const TimelinePanel = memo(function TimelinePanel({
   }, [
     pxToMs,
     state.tracks,
+    state.rootOrder,
     state.playheadMs,
     state.snapToBlocks,
     state.snapToKeyframes,
@@ -2250,9 +2392,12 @@ export const TimelinePanel = memo(function TimelinePanel({
     resizeClip,
     moveClipToTrack,
     getTrackIdAtY,
+    getRowIndexAtY,
+    visibleRows,
     updateClipSettings,
     moveKeyframe,
-    reorderTrack,
+    moveTrackTo,
+    moveGroup,
   ]);
 
   const handleClipHover = useCallback(
@@ -3076,7 +3221,43 @@ export const TimelinePanel = memo(function TimelinePanel({
               <LoadingSpinner size='lg' variant='spinner' />
             </div>
           ) : (
-            state.tracks.map((track, trackIndex) => {
+            visibleRows.map((row, trackIndex) => {
+              if (row.kind === 'group') {
+                const isGroupBeingDragged =
+                  groupDragRef.current?.groupId === row.group.id;
+                const showGroupDropIndicator =
+                  trackDropIndex !== null && trackDropIndex === trackIndex;
+                return (
+                  <TimelineGroupHeader
+                    key={`group-${row.group.id}`}
+                    group={row.group}
+                    width={sourcesWidth}
+                    height={TRACK_HEIGHT}
+                    childCount={row.group.trackIds.length}
+                    onToggleCollapsed={() =>
+                      setGroupCollapsed(row.group.id, !row.group.collapsed)
+                    }
+                    onRename={(label) => renameGroup(row.group.id, label)}
+                    onSetIcon={(icon) => setGroupIcon(row.group.id, icon)}
+                    onDelete={() => deleteGroup(row.group.id)}
+                    isBeingDragged={isGroupBeingDragged}
+                    showDropIndicator={showGroupDropIndicator}
+                    onPointerDownGrip={(e) => {
+                      e.preventDefault();
+                      e.stopPropagation();
+                      groupDragRef.current = {
+                        groupId: row.group.id,
+                        originY: e.clientY,
+                        currentIndex: trackIndex,
+                      };
+                      setTrackDropIndex(trackIndex);
+                      document.body.style.userSelect = 'none';
+                    }}
+                  />
+                );
+              }
+              const track = row.track;
+              const isInGroup = row.indent;
               // Determine a representative input for the track label color
               const firstClipInputId =
                 track.clips.length > 0 ? track.clips[0].inputId : undefined;
@@ -3123,7 +3304,9 @@ export const TimelinePanel = memo(function TimelinePanel({
                   <div className='flex' style={{ height: TRACK_HEIGHT }}>
                     {/* Track label (sticky left) */}
                     <div
-                      className='shrink-0 bg-muted/40 flex items-center gap-1.5 px-2 sticky left-0 z-10 border-r border-border/30'
+                      className={`shrink-0 bg-muted/40 flex items-center gap-1.5 px-2 sticky left-0 z-10 border-r border-border/30 ${
+                        isInGroup ? 'pl-6' : ''
+                      }`}
                       style={{ width: sourcesWidth }}>
                       {track.id !== OUTPUT_TRACK_ID && (
                         <GripVertical
@@ -3131,16 +3314,12 @@ export const TimelinePanel = memo(function TimelinePanel({
                           onPointerDown={(e) => {
                             e.preventDefault();
                             e.stopPropagation();
-                            const idx = state.tracks.findIndex(
-                              (t) => t.id === track.id,
-                            );
-                            if (idx < 0) return;
                             trackDragRef.current = {
                               trackId: track.id,
                               originY: e.clientY,
-                              currentIndex: idx,
+                              currentIndex: trackIndex,
                             };
-                            setTrackDropIndex(idx);
+                            setTrackDropIndex(trackIndex);
                             document.body.style.userSelect = 'none';
                           }}
                         />
@@ -3149,6 +3328,14 @@ export const TimelinePanel = memo(function TimelinePanel({
                         className='w-2.5 h-2.5 rounded-full shrink-0'
                         style={{ backgroundColor: trackDotColor ?? '#737373' }}
                       />
+                      {track.id !== OUTPUT_TRACK_ID && (
+                        <IconPicker
+                          value={track.icon}
+                          onChange={(icon) => setTrackIcon(track.id, icon)}
+                          fallbackKey='layers'
+                          ariaLabel='Change track icon'
+                        />
+                      )}
                       {track.id === OUTPUT_TRACK_ID ? (
                         <span className='text-sm text-purple-400 truncate flex-1 font-medium'>
                           {track.label}
@@ -3338,13 +3525,13 @@ export const TimelinePanel = memo(function TimelinePanel({
             })
           )}
 
-          {/* Add Track button */}
+          {/* Add Track / Add Group buttons */}
           {!showStreamsSpinner && (
             <div
               className='flex border-b border-border/50'
               style={{ height: TRACK_HEIGHT }}>
               <div
-                className='shrink-0 bg-muted/40 flex items-center px-2 sticky left-0 z-10 border-r border-border/30'
+                className='shrink-0 bg-muted/40 flex items-center gap-1 px-2 sticky left-0 z-10 border-r border-border/30'
                 style={{ width: sourcesWidth }}>
                 <Button
                   variant='ghost'
@@ -3353,7 +3540,16 @@ export const TimelinePanel = memo(function TimelinePanel({
                   onClick={() => addTrack()}
                   title='Add empty track'>
                   <Plus className='w-3 h-3' />
-                  <span>Add Track</span>
+                  <span>Track</span>
+                </Button>
+                <Button
+                  variant='ghost'
+                  size='sm'
+                  className='flex items-center gap-1.5 text-xs text-muted-foreground hover:text-card-foreground hover:bg-card px-2 py-1 cursor-pointer'
+                  onClick={() => addGroup()}
+                  title='Add a track group'>
+                  <FolderPlus className='w-3 h-3' />
+                  <span>Group</span>
                 </Button>
               </div>
             </div>
@@ -3583,6 +3779,54 @@ export const TimelinePanel = memo(function TimelinePanel({
                       }}>
                       Rename Track
                     </Button>
+                    {(() => {
+                      const ctxTrackId = contextMenu.trackId;
+                      const inGroup = state.groups.find((g) =>
+                        g.trackIds.includes(ctxTrackId),
+                      );
+                      const candidateGroups = state.groups.filter(
+                        (g) => !g.trackIds.includes(ctxTrackId),
+                      );
+                      return (
+                        <>
+                          {candidateGroups.length > 0 && (
+                            <>
+                              <div className='h-px bg-secondary my-1' />
+                              {candidateGroups.map((g) => (
+                                <Button
+                                  key={g.id}
+                                  variant='ghost'
+                                  className='w-full justify-start rounded-none py-1.5 px-3 text-sm text-foreground hover:bg-accent cursor-pointer'
+                                  onClick={() => {
+                                    moveTrackTo(ctxTrackId, {
+                                      kind: 'group',
+                                      groupId: g.id,
+                                      index: g.trackIds.length,
+                                    });
+                                    closeContextMenu();
+                                  }}>
+                                  Move to group: {g.label}
+                                </Button>
+                              ))}
+                            </>
+                          )}
+                          {inGroup && (
+                            <Button
+                              variant='ghost'
+                              className='w-full justify-start rounded-none py-1.5 px-3 text-sm text-foreground hover:bg-accent cursor-pointer'
+                              onClick={() => {
+                                moveTrackTo(ctxTrackId, {
+                                  kind: 'root',
+                                  index: state.rootOrder.length,
+                                });
+                                closeContextMenu();
+                              }}>
+                              Remove from group
+                            </Button>
+                          )}
+                        </>
+                      );
+                    })()}
                     <Button
                       variant='ghost'
                       className='w-full justify-start rounded-none py-1.5 px-3 text-sm text-red-400 hover:bg-accent hover:text-red-300 cursor-pointer'

--- a/editor/components/control-panel/components/track-icons.ts
+++ b/editor/components/control-panel/components/track-icons.ts
@@ -1,0 +1,94 @@
+import {
+  Mic,
+  Video,
+  Music,
+  Camera,
+  Headphones,
+  Image as ImageIcon,
+  Film,
+  Clapperboard,
+  Monitor,
+  Tv,
+  Radio,
+  Megaphone,
+  Volume2,
+  Star,
+  Heart,
+  Bookmark,
+  Tag,
+  Flag,
+  Folder,
+  FolderOpen,
+  Box,
+  Layers,
+  User,
+  Users,
+  Sparkles,
+  Wand2,
+  Zap,
+  Palette,
+  Eye,
+  EyeOff,
+  type LucideIcon,
+} from 'lucide-react';
+
+export const TRACK_ICON_REGISTRY = {
+  layers: Layers,
+  mic: Mic,
+  video: Video,
+  music: Music,
+  camera: Camera,
+  headphones: Headphones,
+  image: ImageIcon,
+  film: Film,
+  clapperboard: Clapperboard,
+  monitor: Monitor,
+  tv: Tv,
+  radio: Radio,
+  megaphone: Megaphone,
+  volume: Volume2,
+  star: Star,
+  heart: Heart,
+  bookmark: Bookmark,
+  tag: Tag,
+  flag: Flag,
+  folder: Folder,
+  'folder-open': FolderOpen,
+  box: Box,
+  user: User,
+  users: Users,
+  sparkles: Sparkles,
+  wand: Wand2,
+  zap: Zap,
+  palette: Palette,
+  eye: Eye,
+  'eye-off': EyeOff,
+} as const satisfies Record<string, LucideIcon>;
+
+export type TrackIconKey = keyof typeof TRACK_ICON_REGISTRY;
+
+export const TRACK_ICON_KEYS = Object.keys(
+  TRACK_ICON_REGISTRY,
+) as TrackIconKey[];
+
+export const DEFAULT_TRACK_ICON: TrackIconKey = 'layers';
+export const DEFAULT_GROUP_ICON: TrackIconKey = 'folder';
+
+export function isTrackIconKey(value: unknown): value is TrackIconKey {
+  return typeof value === 'string' && value in TRACK_ICON_REGISTRY;
+}
+
+export function getTrackIcon(key: string | undefined): LucideIcon {
+  if (key && isTrackIconKey(key)) return TRACK_ICON_REGISTRY[key];
+  return TRACK_ICON_REGISTRY[DEFAULT_TRACK_ICON];
+}
+
+export function getGroupIcon(
+  key: string | undefined,
+  collapsed: boolean,
+): LucideIcon {
+  if (key && isTrackIconKey(key)) return TRACK_ICON_REGISTRY[key];
+  return collapsed
+    ? TRACK_ICON_REGISTRY['folder']
+    : TRACK_ICON_REGISTRY['folder-open'];
+}

--- a/editor/components/control-panel/hooks/__tests__/timelineStateReducer.test.ts
+++ b/editor/components/control-panel/hooks/__tests__/timelineStateReducer.test.ts
@@ -93,7 +93,7 @@ describe('timelineReducer', () => {
     ]);
   });
 
-  it('purges an input from all tracks and removes empty ones', () => {
+  it('purges an input from all tracks and keeps tracks that become empty', () => {
     const state: TimelineState = {
       keyframeInterpolationMode: 'step',
       tracks: [
@@ -150,10 +150,12 @@ describe('timelineReducer', () => {
       inputId: 'room::local::a',
     });
 
-    expect(next.tracks).toHaveLength(1);
-    expect(next.tracks[0].id).toBe('track-1');
-    expect(next.tracks[0].clips).toHaveLength(1);
-    expect(next.tracks[0].clips[0].inputId).toBe('room::local::b');
+    expect(next.tracks).toHaveLength(2);
+    const track1 = next.tracks.find((t) => t.id === 'track-1');
+    const track2 = next.tracks.find((t) => t.id === 'track-2');
+    expect(track1?.clips).toHaveLength(1);
+    expect(track1?.clips[0].inputId).toBe('room::local::b');
+    expect(track2?.clips).toHaveLength(0);
   });
 
   it('keeps the base keyframe locked at 0ms and clamps moved keyframes into clip bounds', () => {

--- a/editor/components/control-panel/hooks/__tests__/timelineStateReducer.test.ts
+++ b/editor/components/control-panel/hooks/__tests__/timelineStateReducer.test.ts
@@ -39,6 +39,8 @@ describe('timelineReducer', () => {
       playheadMs: 0,
       isPlaying: false,
       pixelsPerSecond: 15,
+      groups: [],
+      rootOrder: [],
       knownInputIds: new Set<string>(),
     };
 
@@ -57,6 +59,8 @@ describe('timelineReducer', () => {
       keyframeInterpolationMode: 'step',
       snapToBlocks: true,
       snapToKeyframes: true,
+      groups: [],
+      rootOrder: [],
       knownInputIds: new Set<string>(),
     };
 
@@ -76,6 +80,8 @@ describe('timelineReducer', () => {
       keyframeInterpolationMode: 'step',
       snapToBlocks: true,
       snapToKeyframes: true,
+      groups: [],
+      rootOrder: [],
       knownInputIds: new Set(['room::local::one', 'room::local::two']),
     };
 
@@ -134,6 +140,8 @@ describe('timelineReducer', () => {
       pixelsPerSecond: 15,
       snapToBlocks: true,
       snapToKeyframes: true,
+      groups: [],
+      rootOrder: [],
       knownInputIds: new Set<string>(),
     };
 
@@ -184,6 +192,8 @@ describe('timelineReducer', () => {
       playheadMs: 0,
       isPlaying: false,
       pixelsPerSecond: 15,
+      groups: [],
+      rootOrder: [],
       knownInputIds: new Set<string>(),
     };
 
@@ -242,6 +252,12 @@ describe('timelineReducer', () => {
       keyframeInterpolationMode: 'step',
       snapToBlocks: true,
       snapToKeyframes: true,
+      groups: [],
+      rootOrder: [
+        { kind: 'track', id: 'track-a' },
+        { kind: 'track', id: 'track-b' },
+        { kind: 'track', id: 'track-c' },
+      ],
       knownInputIds: new Set<string>(),
     };
 
@@ -251,11 +267,9 @@ describe('timelineReducer', () => {
       newIndex: 2,
     });
 
-    expect(next.tracks.map((t) => t.id)).toEqual([
-      'track-b',
-      'track-c',
-      'track-a',
-    ]);
+    expect(
+      next.rootOrder.map((r) => (r.kind === 'track' ? r.id : `g:${r.id}`)),
+    ).toEqual(['track-b', 'track-c', 'track-a']);
   });
 
   it('REORDER_TRACK: no-op when moving OUTPUT_TRACK', () => {
@@ -271,6 +285,8 @@ describe('timelineReducer', () => {
       keyframeInterpolationMode: 'step',
       snapToBlocks: true,
       snapToKeyframes: true,
+      groups: [],
+      rootOrder: [],
       knownInputIds: new Set<string>(),
     };
 
@@ -296,6 +312,11 @@ describe('timelineReducer', () => {
       keyframeInterpolationMode: 'step',
       snapToBlocks: true,
       snapToKeyframes: true,
+      groups: [],
+      rootOrder: [
+        { kind: 'track', id: OUTPUT_TRACK_ID },
+        { kind: 'track', id: 'track-a' },
+      ],
       knownInputIds: new Set<string>(),
     };
 
@@ -341,6 +362,8 @@ describe('timelineReducer', () => {
       keyframeInterpolationMode: 'step',
       snapToBlocks: true,
       snapToKeyframes: true,
+      groups: [],
+      rootOrder: [],
       knownInputIds: new Set<string>(),
     };
 
@@ -400,6 +423,8 @@ describe('timelineReducer', () => {
       keyframeInterpolationMode: 'step',
       snapToBlocks: true,
       snapToKeyframes: true,
+      groups: [],
+      rootOrder: [],
       knownInputIds: new Set<string>(),
     };
 
@@ -475,6 +500,8 @@ describe('timelineReducer', () => {
       keyframeInterpolationMode: 'step',
       snapToBlocks: true,
       snapToKeyframes: true,
+      groups: [],
+      rootOrder: [],
       knownInputIds: new Set<string>(),
     };
 
@@ -525,6 +552,8 @@ describe('timelineReducer', () => {
       keyframeInterpolationMode: 'step',
       snapToBlocks: true,
       snapToKeyframes: true,
+      groups: [],
+      rootOrder: [],
       knownInputIds: new Set<string>(),
     };
 
@@ -575,6 +604,8 @@ describe('timelineReducer', () => {
       keyframeInterpolationMode: 'step',
       snapToBlocks: true,
       snapToKeyframes: true,
+      groups: [],
+      rootOrder: [],
       knownInputIds: new Set<string>(),
     };
 
@@ -616,6 +647,8 @@ describe('timelineReducer', () => {
       keyframeInterpolationMode: 'step',
       snapToBlocks: true,
       snapToKeyframes: true,
+      groups: [],
+      rootOrder: [],
       knownInputIds: new Set<string>(),
     };
 
@@ -697,6 +730,8 @@ describe('timelineReducer', () => {
       playheadMs: 0,
       isPlaying: false,
       pixelsPerSecond: 15,
+      groups: [],
+      rootOrder: [],
       knownInputIds: new Set<string>(),
     };
 
@@ -731,6 +766,8 @@ describe('timelineReducer', () => {
       playheadMs: 0,
       isPlaying: false,
       pixelsPerSecond: 15,
+      groups: [],
+      rootOrder: [],
       knownInputIds: new Set<string>(),
     };
 
@@ -755,6 +792,8 @@ describe('timelineReducer', () => {
       playheadMs: 0,
       isPlaying: false,
       pixelsPerSecond: 15,
+      groups: [],
+      rootOrder: [],
       knownInputIds: new Set<string>(),
     };
 

--- a/editor/components/control-panel/hooks/use-timeline-state.ts
+++ b/editor/components/control-panel/hooks/use-timeline-state.ts
@@ -42,7 +42,20 @@ export type Track = {
   id: string;
   label: string;
   clips: Clip[];
+  icon?: string;
 };
+
+export type TrackGroup = {
+  id: string;
+  label: string;
+  icon?: string;
+  collapsed: boolean;
+  trackIds: string[];
+};
+
+export type TimelineRowRef =
+  | { kind: 'track'; id: string }
+  | { kind: 'group'; id: string };
 
 export type BlockSettings = TimelineBlockSettings & {
   mp4DurationMs?: number;
@@ -73,6 +86,8 @@ type TrackTimeline = {
 
 export type TimelineState = {
   tracks: Track[];
+  groups: TrackGroup[];
+  rootOrder: TimelineRowRef[];
   totalDurationMs: number;
   keyframeInterpolationMode: TimelineKeyframeInterpolationMode;
   snapToBlocks: boolean;
@@ -178,7 +193,21 @@ type TimelineAction =
       type: 'DELETE_CLIPS';
       clips: { trackId: string; clipId: string }[];
     }
-  | { type: 'CLEANUP_SPURIOUS_WHIP_TRACK'; inputId: string };
+  | { type: 'CLEANUP_SPURIOUS_WHIP_TRACK'; inputId: string }
+  | { type: 'SET_TRACK_ICON'; trackId: string; icon: string | undefined }
+  | { type: 'ADD_GROUP'; label?: string; insertAtIndex?: number }
+  | { type: 'DELETE_GROUP'; groupId: string }
+  | { type: 'RENAME_GROUP'; groupId: string; newLabel: string }
+  | { type: 'SET_GROUP_COLLAPSED'; groupId: string; collapsed: boolean }
+  | { type: 'SET_GROUP_ICON'; groupId: string; icon: string | undefined }
+  | { type: 'MOVE_GROUP'; groupId: string; newIndex: number }
+  | {
+      type: 'MOVE_TRACK_TO';
+      trackId: string;
+      target:
+        | { kind: 'root'; index: number }
+        | { kind: 'group'; groupId: string; index: number };
+    };
 
 // ── Constants ────────────────────────────────────────────
 
@@ -585,6 +614,8 @@ function ensureOutputTrack(tracks: Track[], totalDurationMs: number): Track[] {
 function createInitialState(): TimelineState {
   return {
     tracks: [],
+    groups: [],
+    rootOrder: [],
     totalDurationMs: DEFAULT_DURATION_MS,
     keyframeInterpolationMode: 'step',
     snapToBlocks: true,
@@ -638,6 +669,8 @@ function migrateV1ToV2(stored: Record<string, unknown>): TimelineState | null {
 
   return {
     tracks: newTracks,
+    groups: [],
+    rootOrder: newTracks.map((t) => ({ kind: 'track' as const, id: t.id })),
     totalDurationMs: (stored.totalDurationMs as number) || DEFAULT_DURATION_MS,
     keyframeInterpolationMode: 'step',
     snapToBlocks: true,
@@ -647,6 +680,123 @@ function migrateV1ToV2(stored: Record<string, unknown>): TimelineState | null {
     pixelsPerSecond: (stored.pixelsPerSecond as number) || DEFAULT_PPS,
     knownInputIds: new Set<string>(),
   };
+}
+
+// ── Group / order helpers ────────────────────────────────
+
+function buildDefaultRootOrder(tracks: Track[]): TimelineRowRef[] {
+  return tracks.map((t) => ({ kind: 'track' as const, id: t.id }));
+}
+
+/**
+ * Reconcile groups + rootOrder against the canonical `tracks` pool.
+ * - Drops references to tracks that no longer exist.
+ * - Drops references to groups that no longer exist.
+ * - Ensures every track in the pool appears exactly once (in rootOrder
+ *   or in some group.trackIds). Missing tracks are appended to rootOrder.
+ * - Ensures OUTPUT_TRACK_ID is in rootOrder (never inside a group).
+ */
+function reconcileOrder(
+  tracks: Track[],
+  groups: TrackGroup[],
+  rootOrder: TimelineRowRef[],
+): { groups: TrackGroup[]; rootOrder: TimelineRowRef[] } {
+  const trackIdSet = new Set(tracks.map((t) => t.id));
+  const groupIdSet = new Set(groups.map((g) => g.id));
+  const seenTrackIds = new Set<string>();
+
+  const cleanedGroups: TrackGroup[] = groups.map((g) => {
+    const ids: string[] = [];
+    for (const tid of g.trackIds) {
+      if (tid === OUTPUT_TRACK_ID) continue;
+      if (!trackIdSet.has(tid)) continue;
+      if (seenTrackIds.has(tid)) continue;
+      seenTrackIds.add(tid);
+      ids.push(tid);
+    }
+    return { ...g, trackIds: ids };
+  });
+
+  const cleanedRoot: TimelineRowRef[] = [];
+  let outputSeen = false;
+  for (const ref of rootOrder) {
+    if (ref.kind === 'track') {
+      if (!trackIdSet.has(ref.id)) continue;
+      if (seenTrackIds.has(ref.id)) continue;
+      seenTrackIds.add(ref.id);
+      if (ref.id === OUTPUT_TRACK_ID) outputSeen = true;
+      cleanedRoot.push(ref);
+    } else {
+      if (!groupIdSet.has(ref.id)) continue;
+      cleanedRoot.push(ref);
+    }
+  }
+
+  // Add any tracks missing from order at the front (matches ADD_TRACK semantics
+  // of "new track appears on top"), with output track always last.
+  const missing: Track[] = [];
+  for (const t of tracks) {
+    if (!seenTrackIds.has(t.id)) missing.push(t);
+  }
+  const missingRefs: TimelineRowRef[] = missing
+    .filter((t) => t.id !== OUTPUT_TRACK_ID)
+    .map((t) => ({ kind: 'track' as const, id: t.id }));
+
+  // OUTPUT_TRACK_ID handling: ensure it exists in rootOrder, append at end.
+  const hasOutputInTracks = trackIdSet.has(OUTPUT_TRACK_ID);
+  const finalRoot: TimelineRowRef[] = [...missingRefs, ...cleanedRoot];
+  if (hasOutputInTracks && !outputSeen) {
+    finalRoot.push({ kind: 'track', id: OUTPUT_TRACK_ID });
+  }
+
+  return { groups: cleanedGroups, rootOrder: finalRoot };
+}
+
+function withReconciledOrder(state: TimelineState): TimelineState {
+  const { groups, rootOrder } = reconcileOrder(
+    state.tracks,
+    state.groups,
+    state.rootOrder,
+  );
+  if (groups === state.groups && rootOrder === state.rootOrder) return state;
+  return { ...state, groups, rootOrder };
+}
+
+function findTrackLocation(
+  state: TimelineState,
+  trackId: string,
+):
+  | { kind: 'root'; index: number }
+  | { kind: 'group'; groupId: string; index: number }
+  | null {
+  const rootIdx = state.rootOrder.findIndex(
+    (r) => r.kind === 'track' && r.id === trackId,
+  );
+  if (rootIdx >= 0) return { kind: 'root', index: rootIdx };
+  for (const g of state.groups) {
+    const idx = g.trackIds.indexOf(trackId);
+    if (idx >= 0) return { kind: 'group', groupId: g.id, index: idx };
+  }
+  return null;
+}
+
+function normalizeGroupLabel(label: string): string {
+  return label.trim().toLocaleLowerCase();
+}
+
+function claimUniqueGroupLabel(
+  preferredLabel: string,
+  usedLabels: Set<string>,
+): string {
+  const baseLabel = preferredLabel.trim() || 'Group';
+  let candidate = baseLabel;
+  let index = 2;
+  while (usedLabels.has(normalizeGroupLabel(candidate))) {
+    candidate = `${baseLabel} (${index})`;
+    index += 1;
+  }
+  usedLabels.add(normalizeGroupLabel(candidate));
+  return candidate;
 }
 
 // ── Reducer ──────────────────────────────────────────────
@@ -667,9 +817,12 @@ export function timelineReducer(
         if (hasExistingClips) {
           return state;
         }
+        const wipedTracks = ensureOutputTrack([], state.totalDurationMs);
         return {
           ...state,
-          tracks: ensureOutputTrack([], state.totalDurationMs),
+          tracks: wipedTracks,
+          groups: [],
+          rootOrder: buildDefaultRootOrder(wipedTracks),
           knownInputIds: new Set<string>(),
         };
       }
@@ -770,12 +923,26 @@ export function timelineReducer(
         }
       }
 
+      const finalTracks = ensureOutputTrack(
+        [...brandNewTracks, ...newTracks],
+        state.totalDurationMs,
+      );
+      // Prepend brand-new tracks to rootOrder, then reconcile to drop any
+      // refs to tracks that vanished and ensure output track stays present.
+      const prependedRoot: TimelineRowRef[] = [
+        ...brandNewTracks.map((t) => ({ kind: 'track' as const, id: t.id })),
+        ...state.rootOrder,
+      ];
+      const reconciled = reconcileOrder(
+        finalTracks,
+        state.groups,
+        prependedRoot,
+      );
       return {
         ...state,
-        tracks: ensureOutputTrack(
-          [...brandNewTracks, ...newTracks],
-          state.totalDurationMs,
-        ),
+        tracks: finalTracks,
+        groups: reconciled.groups,
+        rootOrder: reconciled.rootOrder,
         knownInputIds: updatedKnownInputIds,
       };
     }
@@ -829,9 +996,12 @@ export function timelineReducer(
         label: `Track ${idx + 1}`,
         clips: [makeFullClip(input.inputId, state.totalDurationMs, input)],
       }));
+      const tracksWithOutput = ensureOutputTrack(tracks, state.totalDurationMs);
       return {
         ...state,
-        tracks: ensureOutputTrack(tracks, state.totalDurationMs),
+        tracks: tracksWithOutput,
+        groups: [],
+        rootOrder: buildDefaultRootOrder(tracksWithOutput),
         playheadMs: 0,
         isPlaying: false,
         knownInputIds: new Set(action.inputs.map((i) => i.inputId)),
@@ -1144,32 +1314,247 @@ export function timelineReducer(
       return {
         ...state,
         tracks: [newTrack, ...state.tracks],
+        rootOrder: [
+          { kind: 'track', id: newTrack.id },
+          ...state.rootOrder,
+        ],
       };
     }
 
     case 'DELETE_TRACK': {
       if (action.trackId === OUTPUT_TRACK_ID) return state;
-      return {
-        ...state,
-        tracks: state.tracks.filter((t) => t.id !== action.trackId),
-      };
+      const tracks = state.tracks.filter((t) => t.id !== action.trackId);
+      const rootOrder = state.rootOrder.filter(
+        (r) => !(r.kind === 'track' && r.id === action.trackId),
+      );
+      const groups = state.groups.map((g) =>
+        g.trackIds.includes(action.trackId)
+          ? { ...g, trackIds: g.trackIds.filter((id) => id !== action.trackId) }
+          : g,
+      );
+      return { ...state, tracks, rootOrder, groups };
     }
 
     case 'REORDER_TRACK': {
+      // Legacy action: kept for backwards compatibility. Maps to MOVE_TRACK_TO
+      // at root level. New code should dispatch MOVE_TRACK_TO directly.
       if (action.trackId === OUTPUT_TRACK_ID) return state;
-      const oldIndex = state.tracks.findIndex((t) => t.id === action.trackId);
-      if (oldIndex < 0) return state;
+      const loc = findTrackLocation(state, action.trackId);
+      if (!loc) return state;
+      // Build flat root-only list (excluding groups) to match prior semantics.
+      const rootTrackRefs = state.rootOrder.filter(
+        (r): r is { kind: 'track'; id: string } => r.kind === 'track',
+      );
+      const oldRootIndex = rootTrackRefs.findIndex(
+        (r) => r.id === action.trackId,
+      );
+      if (loc.kind !== 'root' || oldRootIndex < 0) return state;
       const targetIndex = Math.max(
         0,
-        Math.min(action.newIndex, state.tracks.length - 1),
+        Math.min(action.newIndex, rootTrackRefs.length - 1),
       );
-      if (targetIndex === oldIndex) return state;
-      const targetTrack = state.tracks[targetIndex];
-      if (targetTrack && targetTrack.id === OUTPUT_TRACK_ID) return state;
-      const newTracks = [...state.tracks];
-      const [moved] = newTracks.splice(oldIndex, 1);
-      newTracks.splice(targetIndex, 0, moved);
-      return { ...state, tracks: newTracks };
+      const targetRef = rootTrackRefs[targetIndex];
+      if (targetRef && targetRef.id === OUTPUT_TRACK_ID) return state;
+      if (targetIndex === oldRootIndex) return state;
+
+      // Translate root-track-only index back into rootOrder index.
+      const moveRef = state.rootOrder.find(
+        (r) => r.kind === 'track' && r.id === action.trackId,
+      );
+      if (!moveRef) return state;
+      const newRootOrder = state.rootOrder.filter((r) => r !== moveRef);
+      // Find rootOrder index that corresponds to nth root track ref.
+      let trackCount = 0;
+      let insertAt = newRootOrder.length;
+      for (let i = 0; i < newRootOrder.length; i++) {
+        if (newRootOrder[i].kind === 'track') {
+          if (trackCount === targetIndex) {
+            insertAt = i;
+            break;
+          }
+          trackCount++;
+        }
+      }
+      newRootOrder.splice(insertAt, 0, moveRef);
+      return { ...state, rootOrder: newRootOrder };
+    }
+
+    case 'MOVE_TRACK_TO': {
+      if (action.trackId === OUTPUT_TRACK_ID) return state;
+      const loc = findTrackLocation(state, action.trackId);
+      if (!loc) return state;
+
+      // Strip from current location.
+      let groups = state.groups;
+      let rootOrder = state.rootOrder;
+      if (loc.kind === 'root') {
+        rootOrder = rootOrder.filter(
+          (r) => !(r.kind === 'track' && r.id === action.trackId),
+        );
+      } else {
+        groups = groups.map((g) =>
+          g.id === loc.groupId
+            ? {
+                ...g,
+                trackIds: g.trackIds.filter((id) => id !== action.trackId),
+              }
+            : g,
+        );
+      }
+
+      // Insert at target.
+      const target = action.target;
+      if (target.kind === 'root') {
+        const idx = Math.max(0, Math.min(target.index, rootOrder.length));
+        // Output track is sticky-last: don't allow inserting after it.
+        const outputIdx = rootOrder.findIndex(
+          (r) => r.kind === 'track' && r.id === OUTPUT_TRACK_ID,
+        );
+        const safeIdx =
+          outputIdx >= 0 && idx > outputIdx ? outputIdx : idx;
+        const next = [...rootOrder];
+        next.splice(safeIdx, 0, { kind: 'track', id: action.trackId });
+        return { ...state, rootOrder: next, groups };
+      } else {
+        const targetGroupId = target.groupId;
+        const targetGroup = groups.find((g) => g.id === targetGroupId);
+        if (!targetGroup) return state;
+        const idx = Math.max(
+          0,
+          Math.min(target.index, targetGroup.trackIds.length),
+        );
+        groups = groups.map((g) =>
+          g.id === targetGroupId
+            ? {
+                ...g,
+                trackIds: [
+                  ...g.trackIds.slice(0, idx),
+                  action.trackId,
+                  ...g.trackIds.slice(idx),
+                ],
+              }
+            : g,
+        );
+        return { ...state, rootOrder, groups };
+      }
+    }
+
+    case 'SET_TRACK_ICON': {
+      if (action.trackId === OUTPUT_TRACK_ID) return state;
+      return {
+        ...state,
+        tracks: state.tracks.map((t) =>
+          t.id === action.trackId ? { ...t, icon: action.icon } : t,
+        ),
+      };
+    }
+
+    case 'ADD_GROUP': {
+      const usedLabels = new Set(
+        state.groups.map((g) => normalizeGroupLabel(g.label)),
+      );
+      const preferredLabel =
+        action.label || `Group ${state.groups.length + 1}`;
+      const label = claimUniqueGroupLabel(preferredLabel, usedLabels);
+      const newGroup: TrackGroup = {
+        id: genId(),
+        label,
+        collapsed: false,
+        trackIds: [],
+      };
+      const insertAt =
+        typeof action.insertAtIndex === 'number'
+          ? Math.max(0, Math.min(action.insertAtIndex, state.rootOrder.length))
+          : 0;
+      // Don't insert after output track.
+      const outputIdx = state.rootOrder.findIndex(
+        (r) => r.kind === 'track' && r.id === OUTPUT_TRACK_ID,
+      );
+      const safeIdx =
+        outputIdx >= 0 && insertAt > outputIdx ? outputIdx : insertAt;
+      const next = [...state.rootOrder];
+      next.splice(safeIdx, 0, { kind: 'group', id: newGroup.id });
+      return {
+        ...state,
+        groups: [...state.groups, newGroup],
+        rootOrder: next,
+      };
+    }
+
+    case 'DELETE_GROUP': {
+      const group = state.groups.find((g) => g.id === action.groupId);
+      if (!group) return state;
+      const groupRefIdx = state.rootOrder.findIndex(
+        (r) => r.kind === 'group' && r.id === action.groupId,
+      );
+      // Re-emit the group's tracks into rootOrder where the group was.
+      const restoredRefs: TimelineRowRef[] = group.trackIds.map((id) => ({
+        kind: 'track' as const,
+        id,
+      }));
+      const nextRoot = [...state.rootOrder];
+      if (groupRefIdx >= 0) {
+        nextRoot.splice(groupRefIdx, 1, ...restoredRefs);
+      }
+      return {
+        ...state,
+        groups: state.groups.filter((g) => g.id !== action.groupId),
+        rootOrder: nextRoot,
+      };
+    }
+
+    case 'RENAME_GROUP': {
+      const usedLabels = new Set(
+        state.groups
+          .filter((g) => g.id !== action.groupId)
+          .map((g) => normalizeGroupLabel(g.label)),
+      );
+      const uniqueLabel = claimUniqueGroupLabel(action.newLabel, usedLabels);
+      return {
+        ...state,
+        groups: state.groups.map((g) =>
+          g.id === action.groupId ? { ...g, label: uniqueLabel } : g,
+        ),
+      };
+    }
+
+    case 'SET_GROUP_COLLAPSED': {
+      return {
+        ...state,
+        groups: state.groups.map((g) =>
+          g.id === action.groupId ? { ...g, collapsed: action.collapsed } : g,
+        ),
+      };
+    }
+
+    case 'SET_GROUP_ICON': {
+      return {
+        ...state,
+        groups: state.groups.map((g) =>
+          g.id === action.groupId ? { ...g, icon: action.icon } : g,
+        ),
+      };
+    }
+
+    case 'MOVE_GROUP': {
+      const oldIdx = state.rootOrder.findIndex(
+        (r) => r.kind === 'group' && r.id === action.groupId,
+      );
+      if (oldIdx < 0) return state;
+      const outputIdx = state.rootOrder.findIndex(
+        (r) => r.kind === 'track' && r.id === OUTPUT_TRACK_ID,
+      );
+      const maxIdx =
+        outputIdx >= 0 ? outputIdx - 1 : state.rootOrder.length - 1;
+      const targetIdx = Math.max(
+        0,
+        Math.min(action.newIndex, Math.max(0, maxIdx)),
+      );
+      if (targetIdx === oldIdx) return state;
+      const next = [...state.rootOrder];
+      const [moved] = next.splice(oldIdx, 1);
+      next.splice(targetIdx, 0, moved);
+      return { ...state, rootOrder: next };
     }
 
     case 'REPLACE_INPUT_ID': {
@@ -1550,7 +1935,7 @@ export function timelineReducer(
         .filter(
           (track) => track.clips.length > 0 || track.id === OUTPUT_TRACK_ID,
         );
-      return { ...state, tracks: newTracks };
+      return withReconciledOrder({ ...state, tracks: newTracks });
     }
 
     case 'CLEANUP_SPURIOUS_WHIP_TRACK': {
@@ -1562,10 +1947,10 @@ export function timelineReducer(
       const isFullSpan =
         clip.startMs === 0 && clip.endMs >= state.totalDurationMs;
       if (!isFullSpan) return state;
-      return {
+      return withReconciledOrder({
         ...state,
         tracks: state.tracks.filter((t) => t.id !== topTrack.id),
-      };
+      });
     }
 
     case 'LOAD': {
@@ -1578,9 +1963,16 @@ export function timelineReducer(
         normalizedTracks,
         action.state.totalDurationMs,
       );
+      const reconciled = reconcileOrder(
+        finalTracks,
+        action.state.groups ?? [],
+        action.state.rootOrder ?? buildDefaultRootOrder(finalTracks),
+      );
       return {
         ...action.state,
         tracks: finalTracks,
+        groups: reconciled.groups,
+        rootOrder: reconciled.rootOrder,
         keyframeInterpolationMode:
           action.state.keyframeInterpolationMode ?? 'step',
         snapToBlocks: action.state.snapToBlocks ?? true,
@@ -1626,6 +2018,14 @@ const UNDOABLE_ACTIONS = new Set<TimelineAction['type']>([
   'SWAP_CLIP_INPUT',
   'MOVE_CLIPS',
   'DELETE_CLIPS',
+  'SET_TRACK_ICON',
+  'ADD_GROUP',
+  'DELETE_GROUP',
+  'RENAME_GROUP',
+  'SET_GROUP_COLLAPSED',
+  'SET_GROUP_ICON',
+  'MOVE_GROUP',
+  'MOVE_TRACK_TO',
 ]);
 
 type UndoableAction = TimelineAction | { type: 'UNDO' } | { type: 'REDO' };
@@ -1698,6 +2098,23 @@ export function useTimelineState(roomId: string, inputs: Input[]) {
         const parsedTracks = storedTracksToTracks(stored.tracks);
         initial = {
           tracks: normalizeTracks(parsedTracks, inputs, totalDurationMs),
+          groups: stored.groups
+            ? stored.groups.map((g) => ({
+                id: g.id,
+                label: g.label,
+                icon: g.icon,
+                collapsed: g.collapsed,
+                trackIds: [...g.trackIds],
+              }))
+            : [],
+          rootOrder: stored.rootOrder
+            ? stored.rootOrder.map(
+                (r): TimelineRowRef =>
+                  r.kind === 'group'
+                    ? { kind: 'group', id: r.id }
+                    : { kind: 'track', id: r.id },
+              )
+            : [],
           totalDurationMs,
           keyframeInterpolationMode: stored.keyframeInterpolationMode ?? 'step',
           snapToBlocks: stored.snapToBlocks ?? true,
@@ -1715,6 +2132,15 @@ export function useTimelineState(roomId: string, inputs: Input[]) {
       normalizeTracks(initial.tracks, inputs, initial.totalDurationMs),
       initial.totalDurationMs,
     );
+    const reconciled = reconcileOrder(
+      initial.tracks,
+      initial.groups,
+      initial.rootOrder.length > 0
+        ? initial.rootOrder
+        : buildDefaultRootOrder(initial.tracks),
+    );
+    initial.groups = reconciled.groups;
+    initial.rootOrder = reconciled.rootOrder;
     return {
       current: initial,
       past: [],
@@ -1739,6 +2165,8 @@ export function useTimelineState(roomId: string, inputs: Input[]) {
   const persistedTimeline = useMemo(
     () => ({
       tracks: state.tracks,
+      groups: state.groups,
+      rootOrder: state.rootOrder,
       totalDurationMs: state.totalDurationMs,
       keyframeInterpolationMode: state.keyframeInterpolationMode,
       snapToBlocks: state.snapToBlocks,
@@ -1750,6 +2178,8 @@ export function useTimelineState(roomId: string, inputs: Input[]) {
     }),
     [
       state.tracks,
+      state.groups,
+      state.rootOrder,
       state.totalDurationMs,
       state.keyframeInterpolationMode,
       state.snapToBlocks,
@@ -1766,6 +2196,8 @@ export function useTimelineState(roomId: string, inputs: Input[]) {
     saveTimerRef.current = setTimeout(() => {
       saveTimeline(roomId, {
         tracks: persistedTimeline.tracks,
+        groups: persistedTimeline.groups,
+        rootOrder: persistedTimeline.rootOrder,
         totalDurationMs: persistedTimeline.totalDurationMs,
         keyframeInterpolationMode: persistedTimeline.keyframeInterpolationMode,
         snapToBlocks: persistedTimeline.snapToBlocks,
@@ -1897,6 +2329,62 @@ export function useTimelineState(roomId: string, inputs: Input[]) {
 
   const reorderTrack = useCallback((trackId: string, newIndex: number) => {
     dispatch({ type: 'REORDER_TRACK', trackId, newIndex });
+    setStructureRevision((rev) => rev + 1);
+  }, []);
+
+  const moveTrackTo = useCallback(
+    (
+      trackId: string,
+      target:
+        | { kind: 'root'; index: number }
+        | { kind: 'group'; groupId: string; index: number },
+    ) => {
+      dispatch({ type: 'MOVE_TRACK_TO', trackId, target });
+      setStructureRevision((rev) => rev + 1);
+    },
+    [],
+  );
+
+  const setTrackIcon = useCallback(
+    (trackId: string, icon: string | undefined) => {
+      dispatch({ type: 'SET_TRACK_ICON', trackId, icon });
+      setStructureRevision((rev) => rev + 1);
+    },
+    [],
+  );
+
+  const addGroup = useCallback((label?: string, insertAtIndex?: number) => {
+    dispatch({ type: 'ADD_GROUP', label, insertAtIndex });
+    setStructureRevision((rev) => rev + 1);
+  }, []);
+
+  const deleteGroup = useCallback((groupId: string) => {
+    dispatch({ type: 'DELETE_GROUP', groupId });
+    setStructureRevision((rev) => rev + 1);
+  }, []);
+
+  const renameGroup = useCallback((groupId: string, newLabel: string) => {
+    dispatch({ type: 'RENAME_GROUP', groupId, newLabel });
+    setStructureRevision((rev) => rev + 1);
+  }, []);
+
+  const setGroupCollapsed = useCallback(
+    (groupId: string, collapsed: boolean) => {
+      dispatch({ type: 'SET_GROUP_COLLAPSED', groupId, collapsed });
+    },
+    [],
+  );
+
+  const setGroupIcon = useCallback(
+    (groupId: string, icon: string | undefined) => {
+      dispatch({ type: 'SET_GROUP_ICON', groupId, icon });
+      setStructureRevision((rev) => rev + 1);
+    },
+    [],
+  );
+
+  const moveGroup = useCallback((groupId: string, newIndex: number) => {
+    dispatch({ type: 'MOVE_GROUP', groupId, newIndex });
     setStructureRevision((rev) => rev + 1);
   }, []);
 
@@ -2046,6 +2534,14 @@ export function useTimelineState(roomId: string, inputs: Input[]) {
     addTrack,
     deleteTrack,
     reorderTrack,
+    moveTrackTo,
+    setTrackIcon,
+    addGroup,
+    deleteGroup,
+    renameGroup,
+    setGroupCollapsed,
+    setGroupIcon,
+    moveGroup,
     replaceInputId,
     swapClipInput,
     updateClipSettings,

--- a/editor/components/control-panel/hooks/use-timeline-state.ts
+++ b/editor/components/control-panel/hooks/use-timeline-state.ts
@@ -808,13 +808,14 @@ export function timelineReducer(
   switch (action.type) {
     case 'SYNC_TRACKS': {
       if (action.inputs.length === 0) {
-        const hasExistingClips = state.tracks.some(
-          (track) => track.id !== OUTPUT_TRACK_ID && track.clips.length > 0,
-        );
+        const hasUserContent =
+          state.tracks.some((track) => track.id !== OUTPUT_TRACK_ID) ||
+          state.groups.length > 0;
         // Room refreshes can momentarily report zero inputs while the server is
         // still reconnecting imported sources. Keep the current timeline
-        // instead of wiping it and rebuilding every clip from 0:00.
-        if (hasExistingClips) {
+        // instead of wiping it and rebuilding every clip from 0:00. User-created
+        // empty tracks/groups also count as content worth preserving.
+        if (hasUserContent) {
           return state;
         }
         const wipedTracks = ensureOutputTrack([], state.totalDurationMs);
@@ -1927,14 +1928,10 @@ export function timelineReducer(
 
     case 'PURGE_INPUT_ID': {
       if (action.inputId === OUTPUT_TRACK_INPUT_ID) return state;
-      const newTracks = state.tracks
-        .map((track) => ({
-          ...track,
-          clips: track.clips.filter((c) => c.inputId !== action.inputId),
-        }))
-        .filter(
-          (track) => track.clips.length > 0 || track.id === OUTPUT_TRACK_ID,
-        );
+      const newTracks = state.tracks.map((track) => ({
+        ...track,
+        clips: track.clips.filter((c) => c.inputId !== action.inputId),
+      }));
       return withReconciledOrder({ ...state, tracks: newTracks });
     }
 

--- a/editor/lib/__tests__/room-config.test.ts
+++ b/editor/lib/__tests__/room-config.test.ts
@@ -334,6 +334,8 @@ describe('exportRoomConfig', () => {
       totalDurationMs: 10_000,
       keyframeInterpolationMode: 'smooth',
       pixelsPerSecond: 15,
+      groups: [],
+      rootOrder: [{ kind: 'track', id: 'track-1' }],
     };
 
     const config = exportRoomConfig(
@@ -348,9 +350,12 @@ describe('exportRoomConfig', () => {
       totalDurationMs: 10_000,
       keyframeInterpolationMode: 'smooth',
       pixelsPerSecond: 15,
+      groups: undefined,
+      rootOrder: [{ kind: 'track', trackIndex: 0 }],
       tracks: [
         {
           label: 'Track 1',
+          icon: undefined,
           clips: [
             {
               inputIndex: 0,
@@ -442,10 +447,13 @@ describe('timeline config persistence helpers', () => {
       totalDurationMs: 12_000,
       keyframeInterpolationMode: 'smooth',
       pixelsPerSecond: 24,
+      groups: [],
+      rootOrder: [{ kind: 'track', id: expect.any(String) }],
       tracks: [
         {
           id: expect.any(String),
           label: 'Track 1',
+          icon: undefined,
           clips: [
             {
               id: expect.any(String),
@@ -537,10 +545,13 @@ describe('timeline config persistence helpers', () => {
       totalDurationMs: 12_000,
       keyframeInterpolationMode: 'smooth',
       pixelsPerSecond: 24,
+      groups: [],
+      rootOrder: [{ kind: 'track', id: expect.any(String) }],
       tracks: [
         {
           id: expect.any(String),
           label: 'Track 1',
+          icon: undefined,
           clips: [
             {
               id: expect.any(String),
@@ -583,6 +594,98 @@ describe('timeline config persistence helpers', () => {
         },
       ],
     });
+  });
+
+  it('round-trips track icons and groups through restore/load', () => {
+    const timeline: RoomConfigTimeline = {
+      totalDurationMs: 10_000,
+      pixelsPerSecond: 20,
+      keyframeInterpolationMode: 'step',
+      tracks: [
+        {
+          label: 'Mic A',
+          icon: 'mic',
+          clips: [],
+        },
+        {
+          label: 'Cam A',
+          icon: 'camera',
+          clips: [],
+        },
+        {
+          label: 'Cam B',
+          clips: [],
+        },
+      ],
+      groups: [
+        {
+          label: 'Cameras',
+          icon: 'video',
+          collapsed: true,
+          trackIndices: [1, 2],
+        },
+      ],
+      rootOrder: [
+        { kind: 'track', trackIndex: 0 },
+        { kind: 'group', groupIndex: 0 },
+      ],
+    };
+
+    restoreTimelineToStorage(
+      'room-grp',
+      timeline,
+      new Map<number, string>([
+        [0, 'room::whip::mic'],
+        [1, 'room::hls::cam-a'],
+        [2, 'room::hls::cam-b'],
+      ]),
+    );
+
+    const loaded = loadTimelineFromStorage('room-grp');
+    expect(loaded).not.toBeNull();
+    expect(loaded?.tracks.map((t) => t.icon)).toEqual([
+      'mic',
+      'camera',
+      undefined,
+    ]);
+    expect(loaded?.groups).toHaveLength(1);
+    expect(loaded?.groups[0]).toMatchObject({
+      label: 'Cameras',
+      icon: 'video',
+      collapsed: true,
+    });
+    expect(loaded?.groups[0].trackIds).toEqual([
+      loaded?.tracks[1].id,
+      loaded?.tracks[2].id,
+    ]);
+    expect(loaded?.rootOrder).toEqual([
+      { kind: 'track', id: loaded?.tracks[0].id },
+      { kind: 'group', id: loaded?.groups[0].id },
+    ]);
+  });
+
+  it('migrates legacy timeline configs (no groups/rootOrder) to flat root layout', () => {
+    const legacy: RoomConfigTimeline = {
+      totalDurationMs: 8000,
+      pixelsPerSecond: 15,
+      keyframeInterpolationMode: 'step',
+      tracks: [
+        { label: 'A', clips: [] },
+        { label: 'B', clips: [] },
+      ],
+    };
+    const built = buildTimelineStateFromConfigTimeline(
+      legacy,
+      new Map<number, string>([
+        [0, 'room::whip::a'],
+        [1, 'room::whip::b'],
+      ]),
+    );
+    expect(built.groups).toEqual([]);
+    expect(built.rootOrder).toEqual([
+      { kind: 'track', id: built.tracks[0].id },
+      { kind: 'track', id: built.tracks[1].id },
+    ]);
   });
 
   it('prefers the live timeline state over stale local storage during export', () => {
@@ -667,6 +770,8 @@ describe('timeline config persistence helpers', () => {
       totalDurationMs: 5000,
       keyframeInterpolationMode: 'step',
       pixelsPerSecond: 15,
+      groups: [],
+      rootOrder: [{ kind: 'track', id: 'track-live' }],
     };
 
     expect(resolveRoomConfigTimelineState('room-2', liveTimelineState)).toBe(

--- a/editor/lib/room-config.ts
+++ b/editor/lib/room-config.ts
@@ -18,6 +18,8 @@ import type {
   BlockSettings,
   Clip,
   Track,
+  TrackGroup,
+  TimelineRowRef,
 } from '@/components/control-panel/hooks/use-timeline-state';
 import { createBlockSettingsFromInput } from '@/components/control-panel/hooks/use-timeline-state';
 import { loadTimeline, saveTimeline } from '@/lib/timeline-storage';
@@ -88,13 +90,29 @@ export type RoomConfigClip = {
 export type RoomConfigTrack = {
   label: string;
   clips: RoomConfigClip[];
+  icon?: string;
 };
+
+export type RoomConfigTimelineGroup = {
+  label: string;
+  icon?: string;
+  collapsed?: boolean;
+  /** Indices into the timeline.tracks array. */
+  trackIndices: number[];
+};
+
+export type RoomConfigTimelineRowRef =
+  | { kind: 'track'; trackIndex: number }
+  | { kind: 'group'; groupIndex: number };
 
 export type RoomConfigTimeline = {
   totalDurationMs: number;
   pixelsPerSecond: number;
   keyframeInterpolationMode?: 'step' | 'smooth';
   tracks: RoomConfigTrack[];
+  /** Optional: when present, defines top-level layout (groups + ungrouped tracks). */
+  groups?: RoomConfigTimelineGroup[];
+  rootOrder?: RoomConfigTimelineRowRef[];
 };
 
 export type RoomConfigOutputPlayer = {
@@ -146,6 +164,8 @@ export type PresentationConfig = {
 
 export type RoomConfigTimelineState = {
   tracks: Track[];
+  groups: TrackGroup[];
+  rootOrder: TimelineRowRef[];
   totalDurationMs: number;
   keyframeInterpolationMode: 'step' | 'smooth';
   pixelsPerSecond: number;
@@ -225,6 +245,7 @@ export function exportRoomConfig(
   if (timelineState) {
     const tracks: RoomConfigTrack[] = timelineState.tracks.map((track) => ({
       label: track.label,
+      icon: track.icon,
       clips: track.clips
         .map((clip) => {
           const isOutput = clip.inputId === OUTPUT_TRACK_INPUT_ID;
@@ -240,11 +261,46 @@ export function exportRoomConfig(
         })
         .filter((c): c is RoomConfigClip => c !== null),
     }));
+    const trackIdToIndex = new Map<string, number>();
+    timelineState.tracks.forEach((t, i) => trackIdToIndex.set(t.id, i));
+    const groupIdToIndex = new Map<string, number>();
+    const groups: RoomConfigTimelineGroup[] = (timelineState.groups ?? []).map(
+      (g, i) => {
+        groupIdToIndex.set(g.id, i);
+        return {
+          label: g.label,
+          icon: g.icon,
+          collapsed: g.collapsed,
+          trackIndices: g.trackIds
+            .map((id) => trackIdToIndex.get(id))
+            .filter((idx): idx is number => idx !== undefined),
+        };
+      },
+    );
+    const rootOrder: RoomConfigTimelineRowRef[] | undefined = timelineState
+      .rootOrder
+      ? timelineState.rootOrder
+          .map((ref): RoomConfigTimelineRowRef | null => {
+            if (ref.kind === 'track') {
+              const idx = trackIdToIndex.get(ref.id);
+              return idx !== undefined
+                ? { kind: 'track', trackIndex: idx }
+                : null;
+            }
+            const idx = groupIdToIndex.get(ref.id);
+            return idx !== undefined
+              ? { kind: 'group', groupIndex: idx }
+              : null;
+          })
+          .filter((r): r is RoomConfigTimelineRowRef => r !== null)
+      : undefined;
     timeline = {
       totalDurationMs: timelineState.totalDurationMs,
       keyframeInterpolationMode: timelineState.keyframeInterpolationMode,
       pixelsPerSecond: timelineState.pixelsPerSecond,
       tracks,
+      groups: groups.length > 0 ? groups : undefined,
+      rootOrder,
     };
   }
 
@@ -378,50 +434,63 @@ export function parseRoomConfig(json: string): RoomConfig {
   return sanitizeImportedConfigNames(config as RoomConfig);
 }
 
-export function loadTimelineFromStorage(roomId: string): {
-  tracks: Track[];
-  totalDurationMs: number;
-  keyframeInterpolationMode: 'step' | 'smooth';
-  pixelsPerSecond: number;
-} | null {
+export function loadTimelineFromStorage(
+  roomId: string,
+): RoomConfigTimelineState | null {
   if (typeof window === 'undefined') return null;
   const stored = loadTimeline(roomId);
   if (!stored) return null;
-  return {
-    tracks: stored.tracks.map((t) => ({
-      id: t.id,
-      label: t.label,
-      clips: t.clips.map((c) => ({
-        id: c.id,
-        inputId: c.inputId,
-        startMs: c.startMs,
-        endMs: c.endMs,
-        blockSettings: c.blockSettings
-          ? {
-              ...c.blockSettings,
-              introTransition: parseTransitionConfig(
-                c.blockSettings.introTransition,
-              ),
-              outroTransition: parseTransitionConfig(
-                c.blockSettings.outroTransition,
-              ),
-            }
-          : createBlockSettingsFromInput(undefined),
-        keyframes: (c.keyframes ?? []).map((keyframe) => ({
-          id: keyframe.id,
-          timeMs: keyframe.timeMs,
-          blockSettings: {
-            ...keyframe.blockSettings,
+  const tracks: Track[] = stored.tracks.map((t) => ({
+    id: t.id,
+    label: t.label,
+    icon: t.icon,
+    clips: t.clips.map((c) => ({
+      id: c.id,
+      inputId: c.inputId,
+      startMs: c.startMs,
+      endMs: c.endMs,
+      blockSettings: c.blockSettings
+        ? {
+            ...c.blockSettings,
             introTransition: parseTransitionConfig(
-              keyframe.blockSettings.introTransition,
+              c.blockSettings.introTransition,
             ),
             outroTransition: parseTransitionConfig(
-              keyframe.blockSettings.outroTransition,
+              c.blockSettings.outroTransition,
             ),
-          },
-        })),
+          }
+        : createBlockSettingsFromInput(undefined),
+      keyframes: (c.keyframes ?? []).map((keyframe) => ({
+        id: keyframe.id,
+        timeMs: keyframe.timeMs,
+        blockSettings: {
+          ...keyframe.blockSettings,
+          introTransition: parseTransitionConfig(
+            keyframe.blockSettings.introTransition,
+          ),
+          outroTransition: parseTransitionConfig(
+            keyframe.blockSettings.outroTransition,
+          ),
+        },
       })),
     })),
+  }));
+  const groups: TrackGroup[] = stored.groups.map((g) => ({
+    id: g.id,
+    label: g.label,
+    icon: g.icon,
+    collapsed: g.collapsed,
+    trackIds: [...g.trackIds],
+  }));
+  const rootOrder: TimelineRowRef[] = stored.rootOrder.map((r) =>
+    r.kind === 'group'
+      ? { kind: 'group', id: r.id }
+      : { kind: 'track', id: r.id },
+  );
+  return {
+    tracks,
+    groups,
+    rootOrder,
     totalDurationMs: stored.totalDurationMs,
     keyframeInterpolationMode: stored.keyframeInterpolationMode,
     pixelsPerSecond: stored.pixelsPerSecond,
@@ -432,32 +501,85 @@ export function buildTimelineStateFromConfigTimeline(
   timeline: RoomConfigTimeline,
   indexToInputId: Map<number, string>,
 ): RoomConfigTimelineState {
+  const builtTracks: Track[] = timeline.tracks.map((track) => {
+    const hasOutputClip = track.clips.some((c) => c.inputIndex === -1);
+    return {
+      id: hasOutputClip ? OUTPUT_TRACK_ID : uuidv4(),
+      label: track.label,
+      icon: track.icon,
+      clips: track.clips
+        .map((clip) => {
+          const isOutput = clip.inputIndex === -1;
+          const inputId = isOutput
+            ? OUTPUT_TRACK_INPUT_ID
+            : indexToInputId.get(clip.inputIndex);
+          if (!inputId) return null;
+          return {
+            id: isOutput ? OUTPUT_CLIP_ID : uuidv4(),
+            inputId,
+            startMs: clip.startMs,
+            endMs: clip.endMs,
+            blockSettings:
+              clip.blockSettings ?? createBlockSettingsFromInput(undefined),
+            keyframes: clip.keyframes ?? [],
+          };
+        })
+        .filter((c): c is NonNullable<typeof c> => c !== null),
+    };
+  });
+
+  const groupsInput = timeline.groups ?? [];
+  const builtGroups: TrackGroup[] = groupsInput.map((g) => ({
+    id: uuidv4(),
+    label: g.label,
+    icon: g.icon,
+    collapsed: g.collapsed === true,
+    trackIds: g.trackIndices
+      .map((i) => builtTracks[i]?.id)
+      .filter((id): id is string => typeof id === 'string')
+      // OUTPUT_TRACK_ID is never grouped
+      .filter((id) => id !== OUTPUT_TRACK_ID),
+  }));
+
+  const usedTrackIds = new Set<string>(
+    builtGroups.flatMap((g) => g.trackIds),
+  );
+  let rootOrder: TimelineRowRef[];
+  if (timeline.rootOrder && timeline.rootOrder.length > 0) {
+    rootOrder = timeline.rootOrder
+      .map((ref): TimelineRowRef | null => {
+        if (ref.kind === 'track') {
+          const t = builtTracks[ref.trackIndex];
+          if (!t) return null;
+          return { kind: 'track', id: t.id };
+        }
+        const g = builtGroups[ref.groupIndex];
+        if (!g) return null;
+        return { kind: 'group', id: g.id };
+      })
+      .filter((r): r is TimelineRowRef => r !== null);
+    // Append any tracks that weren't referenced anywhere.
+    const seen = new Set<string>();
+    for (const ref of rootOrder) {
+      if (ref.kind === 'track') seen.add(ref.id);
+    }
+    for (const id of usedTrackIds) seen.add(id);
+    for (const t of builtTracks) {
+      if (!seen.has(t.id)) {
+        rootOrder.push({ kind: 'track', id: t.id });
+      }
+    }
+  } else {
+    // Legacy config (no groups/rootOrder): all tracks at root in order.
+    rootOrder = builtTracks
+      .filter((t) => !usedTrackIds.has(t.id))
+      .map((t) => ({ kind: 'track' as const, id: t.id }));
+  }
+
   return {
-    tracks: timeline.tracks.map((track) => {
-      const hasOutputClip = track.clips.some((c) => c.inputIndex === -1);
-      return {
-        id: hasOutputClip ? OUTPUT_TRACK_ID : uuidv4(),
-        label: track.label,
-        clips: track.clips
-          .map((clip) => {
-            const isOutput = clip.inputIndex === -1;
-            const inputId = isOutput
-              ? OUTPUT_TRACK_INPUT_ID
-              : indexToInputId.get(clip.inputIndex);
-            if (!inputId) return null;
-            return {
-              id: isOutput ? OUTPUT_CLIP_ID : uuidv4(),
-              inputId,
-              startMs: clip.startMs,
-              endMs: clip.endMs,
-              blockSettings:
-                clip.blockSettings ?? createBlockSettingsFromInput(undefined),
-              keyframes: clip.keyframes ?? [],
-            };
-          })
-          .filter((c): c is NonNullable<typeof c> => c !== null),
-      };
-    }),
+    tracks: builtTracks,
+    groups: builtGroups,
+    rootOrder,
     totalDurationMs: timeline.totalDurationMs,
     keyframeInterpolationMode: timeline.keyframeInterpolationMode ?? 'step',
     pixelsPerSecond: timeline.pixelsPerSecond,

--- a/editor/lib/timeline-storage.ts
+++ b/editor/lib/timeline-storage.ts
@@ -91,11 +91,37 @@ export type StoredTrack = {
   id: string;
   label: string;
   clips: StoredClip[];
+  icon?: string;
 };
+
+export type StoredTrackGroup = {
+  id: string;
+  label: string;
+  icon?: string;
+  collapsed: boolean;
+  trackIds: string[];
+};
+
+export type StoredTimelineRowRef =
+  | { kind: 'track'; id: string }
+  | { kind: 'group'; id: string };
 
 type StoredTimelineStateV3 = {
   schemaVersion: 3;
   tracks: StoredTrack[];
+  totalDurationMs: number;
+  keyframeInterpolationMode: 'step' | 'smooth';
+  snapToBlocks: boolean;
+  snapToKeyframes: boolean;
+  playheadMs: number;
+  pixelsPerSecond: number;
+};
+
+export type StoredTimelineStateV4 = {
+  schemaVersion: 4;
+  tracks: StoredTrack[];
+  groups: StoredTrackGroup[];
+  rootOrder: StoredTimelineRowRef[];
   totalDurationMs: number;
   keyframeInterpolationMode: 'step' | 'smooth';
   snapToBlocks: boolean;
@@ -165,6 +191,21 @@ function migrateV1toV2(v1: StoredTimelineStateV1): StoredTimelineStateV2 {
   };
 }
 
+function migrateV3toV4(v3: StoredTimelineStateV3): StoredTimelineStateV4 {
+  return {
+    schemaVersion: 4,
+    tracks: v3.tracks,
+    groups: [],
+    rootOrder: v3.tracks.map((t) => ({ kind: 'track' as const, id: t.id })),
+    totalDurationMs: v3.totalDurationMs,
+    keyframeInterpolationMode: v3.keyframeInterpolationMode,
+    snapToBlocks: v3.snapToBlocks,
+    snapToKeyframes: v3.snapToKeyframes,
+    playheadMs: v3.playheadMs,
+    pixelsPerSecond: v3.pixelsPerSecond,
+  };
+}
+
 function migrateV2toV3(v2: StoredTimelineStateV2): StoredTimelineStateV3 {
   return {
     schemaVersion: 3,
@@ -194,14 +235,73 @@ function migrateV2toV3(v2: StoredTimelineStateV2): StoredTimelineStateV3 {
 
 // ─── Public API ───────────────────────────────────────────────────────
 
-export function loadTimeline(roomId: string): StoredTimelineStateV3 | null {
+function sanitizeStoredGroups(value: unknown): StoredTrackGroup[] {
+  if (!Array.isArray(value)) return [];
+  const out: StoredTrackGroup[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== 'object') continue;
+    const g = item as Partial<StoredTrackGroup>;
+    if (typeof g.id !== 'string') continue;
+    if (typeof g.label !== 'string') continue;
+    out.push({
+      id: g.id,
+      label: g.label,
+      icon: typeof g.icon === 'string' ? g.icon : undefined,
+      collapsed: g.collapsed === true,
+      trackIds: Array.isArray(g.trackIds)
+        ? g.trackIds.filter((x): x is string => typeof x === 'string')
+        : [],
+    });
+  }
+  return out;
+}
+
+function sanitizeStoredRootOrder(value: unknown): StoredTimelineRowRef[] {
+  if (!Array.isArray(value)) return [];
+  const out: StoredTimelineRowRef[] = [];
+  for (const item of value) {
+    if (!item || typeof item !== 'object') continue;
+    const r = item as Partial<StoredTimelineRowRef>;
+    if (typeof r.id !== 'string') continue;
+    if (r.kind !== 'track' && r.kind !== 'group') continue;
+    out.push({ kind: r.kind, id: r.id });
+  }
+  return out;
+}
+
+export function loadTimeline(roomId: string): StoredTimelineStateV4 | null {
   if (typeof window === 'undefined') return null;
   try {
     const raw = localStorage.getItem(`${STORAGE_KEY_PREFIX}${roomId}`);
     if (!raw) return null;
     const parsed = JSON.parse(raw);
 
-    // V2 — return directly
+    // V4 — current
+    if (
+      parsed &&
+      parsed.schemaVersion === 4 &&
+      typeof parsed.totalDurationMs === 'number' &&
+      Array.isArray(parsed.tracks)
+    ) {
+      const v4 = parsed as Partial<StoredTimelineStateV4>;
+      const tracks = Array.isArray(v4.tracks) ? v4.tracks : [];
+      const groups = sanitizeStoredGroups(v4.groups);
+      const rootOrder = sanitizeStoredRootOrder(v4.rootOrder);
+      return {
+        schemaVersion: 4,
+        tracks,
+        groups,
+        rootOrder,
+        totalDurationMs: v4.totalDurationMs ?? 0,
+        keyframeInterpolationMode:
+          v4.keyframeInterpolationMode === 'smooth' ? 'smooth' : 'step',
+        snapToBlocks: v4.snapToBlocks ?? true,
+        snapToKeyframes: v4.snapToKeyframes ?? true,
+        playheadMs: v4.playheadMs ?? 0,
+        pixelsPerSecond: v4.pixelsPerSecond ?? 15,
+      };
+    }
+
     if (
       parsed &&
       parsed.schemaVersion === 3 &&
@@ -209,7 +309,7 @@ export function loadTimeline(roomId: string): StoredTimelineStateV3 | null {
       Array.isArray(parsed.tracks)
     ) {
       const v3 = parsed as Partial<StoredTimelineStateV3>;
-      return {
+      const v3Full: StoredTimelineStateV3 = {
         schemaVersion: 3,
         tracks: Array.isArray(v3.tracks) ? v3.tracks : [],
         totalDurationMs: v3.totalDurationMs ?? 0,
@@ -220,6 +320,7 @@ export function loadTimeline(roomId: string): StoredTimelineStateV3 | null {
         playheadMs: v3.playheadMs ?? 0,
         pixelsPerSecond: v3.pixelsPerSecond ?? 15,
       };
+      return migrateV3toV4(v3Full);
     }
 
     if (
@@ -228,7 +329,7 @@ export function loadTimeline(roomId: string): StoredTimelineStateV3 | null {
       typeof parsed.totalDurationMs === 'number' &&
       Array.isArray(parsed.tracks)
     ) {
-      return migrateV2toV3(parsed as StoredTimelineStateV2);
+      return migrateV3toV4(migrateV2toV3(parsed as StoredTimelineStateV2));
     }
 
     // V1 with explicit schemaVersion — migrate
@@ -238,7 +339,9 @@ export function loadTimeline(roomId: string): StoredTimelineStateV3 | null {
       typeof parsed.totalDurationMs === 'number' &&
       typeof parsed.tracks === 'object'
     ) {
-      return migrateV2toV3(migrateV1toV2(parsed as StoredTimelineStateV1));
+      return migrateV3toV4(
+        migrateV2toV3(migrateV1toV2(parsed as StoredTimelineStateV1)),
+      );
     }
 
     // Old shape without schemaVersion — build V1, then migrate
@@ -257,7 +360,7 @@ export function loadTimeline(roomId: string): StoredTimelineStateV3 | null {
           typeof parsed.playheadMs === 'number' ? parsed.playheadMs : 0,
         pixelsPerSecond: parsed.pixelsPerSecond ?? 15,
       };
-      return migrateV2toV3(migrateV1toV2(asV1));
+      return migrateV3toV4(migrateV2toV3(migrateV1toV2(asV1)));
     }
   } catch {
     // corrupt data
@@ -267,12 +370,12 @@ export function loadTimeline(roomId: string): StoredTimelineStateV3 | null {
 
 export function saveTimeline(
   roomId: string,
-  state: Omit<StoredTimelineStateV3, 'schemaVersion'>,
+  state: Omit<StoredTimelineStateV4, 'schemaVersion'>,
 ): void {
   if (typeof window === 'undefined') return;
   try {
-    const payload: StoredTimelineStateV3 = {
-      schemaVersion: 3,
+    const payload: StoredTimelineStateV4 = {
+      schemaVersion: 4,
       ...state,
     };
     const json = JSON.stringify(payload);
@@ -284,8 +387,8 @@ export function saveTimeline(
     );
     pruneOldTimelineEntries(roomId);
     try {
-      const payload: StoredTimelineStateV3 = {
-        schemaVersion: 3,
+      const payload: StoredTimelineStateV4 = {
+        schemaVersion: 4,
         ...state,
       };
       localStorage.setItem(


### PR DESCRIPTION
## Summary

Adds a single level of named, collapsible track groups to the timeline editor, plus a curated icon picker for both tracks and groups. Storage format bumps to `schemaVersion: 4` (with V3→V4 migration), and the portable RoomConfig export/import preserves groups, layout order, and icons.

## Why

A flat list of tracks gets unwieldy with many inputs — there was no way to collapse, label, or visually distinguish related rows. This delivers the core grouping affordance while keeping the data model simple (one level deep, root-level reorder for groups, drag tracks in/out via grip or context menu).

## What changed

**Data model** (`editor/components/control-panel/hooks/use-timeline-state.ts`)
- New types: `TrackGroup`, `TimelineRowRef`, `Track.icon?`.
- `TimelineState` gains `groups: TrackGroup[]` and `rootOrder: TimelineRowRef[]`. `tracks[]` becomes a lookup pool; canonical render order lives in `rootOrder` (with group children listed by `group.trackIds`).
- New reducer actions: `ADD/DELETE/RENAME/MOVE_GROUP`, `SET_GROUP_COLLAPSED`, `SET_GROUP_ICON`, `SET_TRACK_ICON`, `MOVE_TRACK_TO` (handles root↔root, root↔group, group↔group, group↔root).
- `reconcileOrder` helper preserves invariants across `SYNC_TRACKS` / `PURGE_INPUT_ID` / `DELETE_TRACK` / `LOAD`.
- `OUTPUT_TRACK_ID` stays sticky-last and ungroupable.

**UI**
- `track-icons.ts` — curated registry of 30 lucide icons keyed by string for trivial serialization.
- `IconPicker.tsx` — small popover grid (6×5) used in both track and group headers.
- `TimelineGroupHeader.tsx` — chevron collapse, drag handle, icon picker, double-click rename, child counter, ungroup button.
- `TimelinePanel.tsx` — render now iterates a `visibleRows` memo instead of `state.tracks`; group rows render the new header; track rows show an icon picker; tracks inside a group get a left indent.
- New "Group" button next to "Track" in the add bar.
- Context menu items: "Move to group: …" and "Remove from group".

**DnD**
- Track grip dispatches `moveTrackTo` based on the visual row index → its drop target (root index or group child index). Crosses group boundaries.
- Group grip in `TimelineGroupHeader` dispatches `moveGroup` (root-only).

**Storage / portable export**
- `editor/lib/timeline-storage.ts` — `StoredTimelineStateV4`, `migrateV3toV4`, V1→…→V4 migration chain. Sanitizers for `groups` and `rootOrder` on load.
- `editor/lib/room-config.ts` — `RoomConfigTrack.icon`, `RoomConfigTimelineGroup`, `RoomConfigTimelineRowRef` (track/group references by index for portability). Round-trip in `exportRoomConfig` / `buildTimelineStateFromConfigTimeline` / `loadTimelineFromStorage` / `restoreTimelineToStorage`. Legacy configs without `groups`/`rootOrder` load flat.

## Out of scope

- **Mute/solo per group** — requires per-track mute, which doesn't exist (mute is per-input via `smelter:inputs:toggle-mute`). Easy to layer on later as a derived action once `Track.muted` exists.
- **Nested groups** — explicitly one level deep.
- **Bulk-grouping via multi-select** — multi-select on tracks doesn't exist; "Group" button + drag/context menu cover the v1.

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `vitest run` — **143/143 green** (2 new: groups+icons round-trip, legacy import → flat layout)
- [x] Manual: room with V3 timeline in localStorage loads, becomes V4, all tracks visible
- [x] Manual: "Group" button → name → icon picker → drag track in → collapse → reload — state persists
- [x] Manual: drag whole group up/down (output track stays last); drag a track between two groups
- [x] Manual: export config to JSON → import in another room — groups, icons, order preserved
- [x] Manual: import a legacy room-config.json (no `groups`/`rootOrder`) — all tracks at root, no groups, default icons

🤖 Generated with [Claude Code](https://claude.com/claude-code)