### PR TITLE
Copy AI-model runtime assets into dist so sidecars work in Docker

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/index.js",
   "license": "MIT",
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && ./scripts/copy-ai-assets.sh",
     "lint": "eslint .",
     "start": "set -a; [ -f .env.local ] && . ./.env.local; set +a; ts-node ./src/index.ts",
     "test": "vitest",

--- a/server/scripts/copy-ai-assets.sh
+++ b/server/scripts/copy-ai-assets.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# tsc emits only .js, but the AI-model manifests resolve worker.py,
+# requirements.txt and YOLO weights via __dirname — which is dist/ai-models/*
+# when the server runs from dist. Copy those runtime assets next to the
+# compiled output so the sidecars work outside ts-node.
+set -e
+cd "$(dirname "$0")/.."
+
+for src_dir in src/ai-models/*/; do
+  model=$(basename "$src_dir")
+  dst_dir="dist/ai-models/$model"
+  mkdir -p "$dst_dir"
+  find "$src_dir" -maxdepth 1 \
+    \( -name '*.py' -o -name 'requirements*.txt' -o -name '*.pt' \) \
+    -exec cp {} "$dst_dir/" \;
+done


### PR DESCRIPTION
## Summary
- `tsc` emits only `.js`, but the AI-model manifests resolve `worker.py`, `requirements.txt` and YOLO `.pt` weights via `__dirname` — which points at `dist/ai-models/*` when the server runs from compiled output (`node dist`, i.e. every Docker image).
- Without this, all AI-model sidecars except captions silently fail in production/staging images; until now this was patched locally on the dev box via a hand-edited `entrypoint.dev.sh`.
- Adds `server/scripts/copy-ai-assets.sh` and runs it as part of `pnpm build`, so both the Docker image build and the dev entrypoint (which also runs `pnpm build`) get the assets with no extra steps.

## Notes for deploy
- First enable of a model on a fresh container still installs its Python venv at runtime (~15 min for torch/ultralytics/mediapipe) and the venv lives in the container layer, so it's lost on recreate. Baking venvs into the image or persisting them via volumes in `compose.production.yaml` is a possible follow-up.

## Test plan
- `pnpm build` locally → `dist/ai-models/*/` contains `worker.py`, `requirements*.txt` and `.pt` weights.
- Build the Docker image and enable a model → logs reach `[ai:<model>] python connected` / `wsSent=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)