### PR TITLE
Serialize shared-venv setup across AI-model sidecars

### DIFF
--- a/server/src/ai-models/base-sidecar.ts
+++ b/server/src/ai-models/base-sidecar.ts
@@ -8,6 +8,9 @@ import type { ModelManifest } from './registry';
 
 const execFileAsync = promisify(execFile);
 
+// Tail of the setup chain per venv directory — see setupPython().
+const venvSetupQueues = new Map<string, Promise<void>>();
+
 export type ModelResultEvent = {
   modelId: string;
   inputId: string;
@@ -265,6 +268,20 @@ export abstract class BaseSidecar extends EventEmitter {
       return;
     }
 
+    // Sidecars can share a venv (every people-counter backend plus the car
+    // models install into people-counter's .venv). Concurrent `pip install`
+    // runs into the same site-packages corrupt each other, so queue setups
+    // per venvDir; once the first finishes, the depsCheck in installVenv
+    // passes and the queued ones return immediately.
+    const prev = venvSetupQueues.get(venvDir) ?? Promise.resolve();
+    const current = prev.then(() => this.installVenv());
+    venvSetupQueues.set(venvDir, current);
+    return current;
+  }
+
+  /** Never rejects — a failed install is logged and the model stays broken. */
+  private async installVenv(): Promise<void> {
+    const { requirementsFile, venvDir, depsCheck } = this.manifest;
     const venvPython = this.getVenvPython();
     if (existsSync(venvPython)) {
       try {


### PR DESCRIPTION
## Summary
- All people-counter backends (yolo, yolo-birds, haar, mediapipe) plus car-ads/car-hue install into the same `dist/ai-models/people-counter/.venv`, and each sidecar ran its own `pip install` on startup. On a fresh container this launches ~6 concurrent pip processes writing into one `site-packages`, which corrupt each other (`ERROR: Could not install packages due to an OSError: [Errno 2] No such file or directory: .../site-packages/...`) — observed on both the dev box and the first post-#159 production boot.
- Fix: a module-level per-`venvDir` promise queue in `BaseSidecar.setupPython()`. The first sidecar installs; the rest wait, then hit the fast `depsCheck` path (`Venv ready`) instead of racing pip.

## Test plan
- `tsc --noEmit` clean.
- Fresh container boot: logs should show exactly one `Setting up Python venv...` per distinct venv, followed by `Venv ready` for the sharing sidecars — no `Failed to setup venv` races.

🤖 Generated with [Claude Code](https://claude.com/claude-code)