### PR TITLE
Remove leftover merge-conflict markers from Duckhunt fix

### DIFF
--- a/editor/app/mobile/[roomId]/shoot/page.tsx
+++ b/editor/app/mobile/[roomId]/shoot/page.tsx
@@ -9,17 +9,9 @@ import { startPublish } from '@/components/control-panel/whip-input/utils/whip-p
 import {
   applyServerUrlFromQueryParam,
   getEffectiveClientServerUrl,
-<<<<<<< Updated upstream
-  getStoredClientServerUrl,
-  isLoopbackHost,
-=======
-<<<<<<< Updated upstream
-=======
   getPublicDefaultServerUrl,
   getStoredClientServerUrl,
   isLoopbackHost,
->>>>>>> Stashed changes
->>>>>>> Stashed changes
   toWsUrl,
 } from '@/lib/server-url';
 
@@ -564,17 +556,6 @@ export default function ShootControllerPage() {
   }, [stage, fire]);
 
   const connectWs = useCallback(() => {
-<<<<<<< Updated upstream
-    const base = toWsUrl(
-      getStoredClientServerUrl() ??
-        remoteOrigin() ??
-        getEffectiveClientServerUrl(),
-    );
-=======
-<<<<<<< Updated upstream
-    const ro = remoteOrigin();
-    const base = toWsUrl(ro ?? getEffectiveClientServerUrl());
-=======
     // Explicit `?server=` wins; then the public build-time default (a phone on
     // the static deploy must not try same-origin — Vercel can't proxy WS);
     // same-origin only remains for the tunnel case, where the page's own
@@ -585,8 +566,6 @@ export default function ShootControllerPage() {
         remoteOrigin() ??
         getEffectiveClientServerUrl(),
     );
->>>>>>> Stashed changes
->>>>>>> Stashed changes
     const url = `${base}/room/${encodeURIComponent(String(roomId))}/ws`;
     setWsDbg(`connecting: ${url}`);
     const ws = new WebSocket(url);
@@ -1282,11 +1261,6 @@ function remoteOrigin(): string | null {
   const o = window.location.origin;
   return /(localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\])/.test(o) ? null : o;
 }
-<<<<<<< Updated upstream
-=======
-<<<<<<< Updated upstream
-=======
->>>>>>> Stashed changes
 
 // Media endpoints (WHIP/WHEP) come from the server, which may only know its
 // loopback address. When such a URL would be unreachable from the phone, graft
@@ -1294,12 +1268,8 @@ function remoteOrigin(): string | null {
 // prefix) or, failing that, onto this page's own origin. URLs that are already
 // public (e.g. an instance behind nginx) pass through untouched.
 function resolveMediaUrl(url: string): string {
-<<<<<<< Updated upstream
-  const base = getStoredClientServerUrl() ?? remoteOrigin();
-=======
   const base =
     getStoredClientServerUrl() ?? getPublicDefaultServerUrl() ?? remoteOrigin();
->>>>>>> Stashed changes
   if (!base) return url;
   try {
     const u = new URL(url);
@@ -1309,7 +1279,3 @@ function resolveMediaUrl(url: string): string {
     return url;
   }
 }
-<<<<<<< Updated upstream
-=======
->>>>>>> Stashed changes
->>>>>>> Stashed changes

--- a/editor/components/dashboard/duck-hunter-panel.tsx
+++ b/editor/components/dashboard/duck-hunter-panel.tsx
@@ -10,17 +10,10 @@ import {
   setAIModel,
   setDuckHunterConfig,
 } from '@/app/actions/actions';
-<<<<<<< Updated upstream
-import { getStoredClientServerUrl } from '@/lib/server-url';
-=======
-<<<<<<< Updated upstream
-=======
 import {
   getPublicDefaultServerUrl,
   getStoredClientServerUrl,
 } from '@/lib/server-url';
->>>>>>> Stashed changes
->>>>>>> Stashed changes
 import { Button } from '@/components/ui/button';
 import { Slider } from '@/components/ui/slider';
 import {
@@ -215,25 +208,13 @@ export function DuckHunterPanel({ roomId }: Props) {
   const shootUrl = useMemo(() => {
     const b = base.trim().replace(/\/+$/, '');
     if (!b) return '';
-<<<<<<< Updated upstream
-=======
-<<<<<<< Updated upstream
-    return `${b}/mobile/${encodeURIComponent(roomId)}/shoot`;
-=======
->>>>>>> Stashed changes
     const url = `${b}/mobile/${encodeURIComponent(roomId)}/shoot`;
     // If this editor talks to a publicly reachable API (e.g. an instance behind
     // nginx), bake it into the link so the phone targets the same backend even
     // when the page itself is served from a static deploy (Vercel). A loopback
     // API is unreachable from a phone, so the page's own-origin fallback stays.
-<<<<<<< Updated upstream
-    const api = getStoredClientServerUrl();
-    return api ? `${url}?server=${encodeURIComponent(api)}` : url;
-=======
     const api = getStoredClientServerUrl() ?? getPublicDefaultServerUrl();
     return api ? `${url}?server=${encodeURIComponent(api)}` : url;
->>>>>>> Stashed changes
->>>>>>> Stashed changes
   }, [base, roomId]);
 
   const onBaseChange = (value: string) => {

--- a/editor/lib/server-url.ts
+++ b/editor/lib/server-url.ts
@@ -143,11 +143,6 @@ export function setStoredServerUrl(url: string | null): void {
   document.cookie = `${SERVER_URL_COOKIE_NAME}=${encodeURIComponent(normalized)}; Path=/; Max-Age=${ONE_YEAR_SECONDS}; SameSite=Lax`;
 }
 
-<<<<<<< Updated upstream
-=======
-<<<<<<< Updated upstream
-=======
->>>>>>> Stashed changes
 /**
  * The server URL the user picked explicitly (via `?server=` deep link or the
  * server selector) — or null when unset or a loopback address. Callers use it
@@ -155,15 +150,9 @@ export function setStoredServerUrl(url: string | null): void {
  * the Vercel deploy) can still be told to talk to a public API elsewhere.
  */
 export function getStoredClientServerUrl(): string | null {
-<<<<<<< Updated upstream
-  if (getStoredAppMode() === 'demo') {
-    return null;
-  }
-=======
   // Deliberately NOT gated on demo mode: phones scanning a workshop QR run in
   // the default demo mode, and the `?server=` baked into that QR is the only
   // way they can reach the right backend from a static (Vercel) deploy.
->>>>>>> Stashed changes
   const stored = getStoredServerUrl();
   if (!stored) {
     return null;
@@ -178,8 +167,6 @@ export function getStoredClientServerUrl(): string | null {
   return stored;
 }
 
-<<<<<<< Updated upstream
-=======
 /**
  * The build-time default server URL when it is reachable from another device
  * (non-loopback) — e.g. the public API baked into the Vercel deploy. Null in
@@ -195,8 +182,6 @@ export function getPublicDefaultServerUrl(): string | null {
   }
 }
 
->>>>>>> Stashed changes
->>>>>>> Stashed changes
 export function getEffectiveClientServerUrl(): string {
   const raw =
     getStoredAppMode() === 'demo'


### PR DESCRIPTION
PR #163 landed with unresolved `<<<<<<<` / `>>>>>>>` conflict markers in `server-url.ts`, `shoot/page.tsx` and `duck-hunter-panel.tsx` (botched stash pop), so **main currently does not compile** and Vercel keeps serving the previous build — phones still get the old same-origin WS logic and stay "offline".

This restores the intended content of the fix:

- `getStoredClientServerUrl()` no longer returns `null` in demo mode — a phone that scanned a workshop QR (demo by default) honors the `?server=` deep link
- new `getPublicDefaultServerUrl()`: the build-time public API URL (non-loopback), used as fallback before the same-origin heuristic for the shoot page WS + WHIP/WHEP and for the Duck Hunter QR link — so even a link *without* `?server=` reaches the right backend from the Vercel deploy
- server actions honor the `?server=` cookie in demo mode too, keeping room info, WS and media on the same backend

Verified: no conflict markers left, `tsc --noEmit` clean (only the 4 pre-existing CSS side-effect import errors also present on clean main).

After merge, Vercel rebuilds and the phone should go "online" — no special link needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)